### PR TITLE
Podman (tested in Fedora 37)

### DIFF
--- a/zwift.sh
+++ b/zwift.sh
@@ -1,7 +1,8 @@
 #!/bin/bash +x
 
 # Use podman if available
-if [ -x "$(command -v podman)" ]; then
+if [[ -x "$(command -v podman)" ]]
+then
         CONTAINER_TOOL=podman
 else
         CONTAINER_TOOL=docker
@@ -18,6 +19,7 @@ VERSION=${VERSION:-latest}
 
 # Create the zwift home directory if not already exists
 mkdir -p $ZWIFT_HOME
+$CONTAINER_TOOL unshare chown $UID:$UID -R $ZWIFT_HOME
 
 # Check for updated container image
 $CONTAINER_TOOL pull $IMAGE:$VERSION

--- a/zwift.sh
+++ b/zwift.sh
@@ -1,4 +1,11 @@
-#!/bin/bash
+#!/bin/bash +x
+
+# Use podman if available
+if [ -x "$(command -v podman)" ]; then
+        CONTAINER_TOOL=podman
+else
+        CONTAINER_TOOL=docker
+fi
 
 # The home directory to store zwift data
 ZWIFT_HOME=${ZWIFT_HOME:-$HOME/.zwift/$USER}
@@ -13,7 +20,7 @@ VERSION=${VERSION:-latest}
 mkdir -p $ZWIFT_HOME
 
 # Check for updated container image
-docker pull $IMAGE:$VERSION
+$CONTAINER_TOOL pull $IMAGE:$VERSION
 
 # Check for proprietary nvidia driver and set correct device to use
 if [[ -f "/proc/driver/nvidia/version" ]]
@@ -24,7 +31,7 @@ else
 fi
 
 # Start the zwift container
-CONTAINER=$(docker run \
+CONTAINER=$($CONTAINER_TOOL run \
 	-d \
 	--rm \
 	--privileged \
@@ -36,4 +43,4 @@ CONTAINER=$(docker run \
 	$IMAGE:$VERSION)
 	
 # Allow container to connect to X
-xhost +local:$(docker inspect --format='{{ .Config.Hostname  }}' $CONTAINER)
+xhost +local:$($CONTAINER_TOOL inspect --format='{{ .Config.Hostname  }}' $CONTAINER)


### PR DESCRIPTION
This is a small patch to use podman (by default in Fédora) when it's available.
And `unshare chown $UID:$UID` otherwise the container could not write in ~/.zwift/