### PR TITLE
Using named volume instead of file mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ If you want a proper setup then please use `zwift.sh`.
 
 ## Logging in automatically with zwift.sh
 
-To authenticate through Zwift automatically, the credentials must be present in the mounted persisted Zwift config volume (`$HOME/.config/zwift/$USER/.zwift-credentials`).
+To authenticate through Zwift automatically, the credentials must be present in the zwift volume.
+`docker volume ls` or `podman volume ls` should have a `zwift-$USER` volume.
 A file named `.zwift-credentials` must contain the following lines:
 
 ```
@@ -56,6 +57,20 @@ ZWIFT_PASSWORD=password
 ```
 
 where `username` is your Zwift account email, and `password` your Zwift account password, respectively.
+
+copy this file into your zwift volume `zwift-$USER`:
+
+```console
+# docker
+docker run -v zwift-$USER:/data --name zwift-copy-op busybox true
+docker cp .zwift-credentials zwift-copy-op:/data
+docker rm zwift-copy-op
+
+# podman
+podman unshare
+cp .zwift-credentials $(podman volume mount zwift-$USER)
+exit
+```
 
 The credentials will be used to authenticate before launching the Zwift app, and the user should be logged in automatically in the game.
 

--- a/zwift.sh
+++ b/zwift.sh
@@ -1,18 +1,11 @@
 #!/usr/bin/env bash
 set -x
 
-# The home directory to store zwift data
-ZWIFT_HOME=${ZWIFT_HOME:-$HOME/.config/zwift/$USER}
-mkdir -p $ZWIFT_HOME
-
 # Set the container image to use
 IMAGE=${IMAGE:-docker.io/netbrain/zwift}
 
 # The container version
 VERSION=${VERSION:-latest}
-
-# Create the zwift home directory if not already exists
-mkdir -p $ZWIFT_HOME
 
 # Use podman if available
 if [[ ! $CONTAINER_TOOL ]]
@@ -20,7 +13,6 @@ then
     if [[ -x "$(command -v podman)" ]]
     then
         CONTAINER_TOOL=podman
-        $CONTAINER_TOOL unshare chown $UID:$UID -R $ZWIFT_HOME
     else
         CONTAINER_TOOL=docker
     fi
@@ -35,26 +27,27 @@ fi
 # Check for proprietary nvidia driver and set correct device to use
 if [[ -f "/proc/driver/nvidia/version" ]]
 then
-	VGA_DEVICE_FLAG="--gpus all"
+    VGA_DEVICE_FLAG="--gpus all"
 else
-	VGA_DEVICE_FLAG="--device /dev/dri:/dev/dri"
+    VGA_DEVICE_FLAG="--device /dev/dri:/dev/dri"
 fi
 
 
 # Start the zwift container
 CONTAINER=$($CONTAINER_TOOL run \
-	-d \
-	--rm \
-	--privileged \
-	-e DISPLAY=$DISPLAY \
-	-v /tmp/.X11-unix:/tmp/.X11-unix \
-	-v /run/user/$UID/pulse:/run/user/1000/pulse \
-	-v $ZWIFT_HOME:/home/user/Zwift \
-	$VGA_DEVICE_FLAG \
-	$IMAGE:$VERSION)
+    -d \
+    --rm \
+    --privileged \
+    -e DISPLAY=$DISPLAY \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -v /run/user/$UID/pulse:/run/user/1000/pulse \
+    -v zwift-$USER:/home/user/Zwift \
+    $([ "$CONTAINER_TOOL" = "podman" ] && printf '--userns=keep-id') \
+    $VGA_DEVICE_FLAG \
+    $IMAGE:$VERSION)
 
 if [[ -z $WAYLAND_DISPLAY ]]
 then
-	# Allow container to connect to X
-	xhost +local:$($CONTAINER_TOOL inspect --format='{{ .Config.Hostname  }}' $CONTAINER)
+    # Allow container to connect to X
+    xhost +local:$($CONTAINER_TOOL inspect --format='{{ .Config.Hostname  }}' $CONTAINER)
 fi


### PR DESCRIPTION
Circumventing podman and UID/GID's issues by using a named volume for zwift persisted config instead of relying on file mounts.

Fixes #19 
