### PR TITLE
[ doc ] note for strong passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ ZWIFT_PASSWORD=password
 ```
 
 where `username` is your Zwift account email, and `password` your Zwift account password, respectively.
+Note that if your password contains special characters such as `;` you will need to escape them using `\`. 
 
 copy this file into your zwift volume `zwift-$USER`:
 


### PR DESCRIPTION
Passwords using special characters need escaping. Otherwise authentication just fails because the variable only got assigned part of the password.