### PR TITLE
Fix ZwiftApp process detection loop

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -89,7 +89,7 @@ fi
 
 sleep 3
 
-until pgrep ZwiftApp.exe &> /dev/null
+until pgrep -f ZwiftApp.exe &> /dev/null
 do
     echo "Waiting for zwift to start ..."
     sleep 1


### PR DESCRIPTION
Since the 1.1.11 launcher update or 1.56 game update, the entrypoint script loops waiting for ZwiftApp.exe to be started.

It used to work but for some reason it doesn't anymore.
I could reproduce the issue locally as well as with the `netbrain/zwift` image.
Using `pgrep -f` finds the process correctly now.