### PR TITLE
additional package source for newer mesa-libGL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ENV WINEDEBUG=${WINEDEBUG:-fixme-all}
 
 RUN dpkg --add-architecture i386 
 
-RUN echo "deb http://ftp.de.debian.org/debian sid main" >> /etc/apt/sources.list
+RUN echo "deb http://ftp.debian.org/debian sid main" >> /etc/apt/sources.list
 
 RUN \
   apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ ENV WINEDEBUG=${WINEDEBUG:-fixme-all}
 
 RUN dpkg --add-architecture i386 
 
+RUN echo "deb http://ftp.de.debian.org/debian sid main" >> /etc/apt/sources.list
+
 RUN \
   apt-get update && \
   apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Resolve glxinfo errors on recent Fedora host version (39) in combination with Radeon GPU