### PR TITLE
Add ability to set container networking mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Note you might want to disable video screenshots ([#75](https://github.com/netbr
 | ZWIFT_USERNAME           |                         | If set, try to login to zwift automatically               |
 | ZWIFT_PASSWORD           |                         | "                                                         |
 | WINE_EXPERIMENTAL_WAYLAND|                         | If set, try to use experimental wayland support in wine 9 |
+| NETWORKING               | bridge                  | Sets the type of container networking to use.             |
 
 These environment variables can be used to alter the execution of the zwift bash script. 
 
@@ -55,6 +56,8 @@ Examples:
 `CONTAINER_TOOL=docker zwift` will launch zwift with docker even if podman is installed
 
 `USER=Fred zwift` perfect if your neighbor fred want's to try zwift, and you don't want to mess up your zwift config.
+
+`NETWORKING=host zwift` will use host networking which may be needed to have Zwift talk to WiFi enabled trainers.
 
 You can also set these in `~/.config/zwift/config` to be sourced by the zwift.sh script on execution.
 

--- a/zwift.sh
+++ b/zwift.sh
@@ -33,6 +33,8 @@ else
     VGA_DEVICE_FLAG="--device /dev/dri:/dev/dri"
 fi
 
+NETWORKING=${NETWORKING:-bridge}
+
 ### OVERRIDE CONFIGURATION FROM FILE ###
 
 # Check for other zwift configuration, sourced here and passed on to container aswell
@@ -76,6 +78,7 @@ CONTAINER=$($CONTAINER_TOOL run \
     -d \
     --rm \
     --privileged \
+    --network $NETWORKING \
     -e DISPLAY=$DISPLAY \
     -v /tmp/.X11-unix:/tmp/.X11-unix \
     -v /run/user/$UID/pulse:/run/user/1000/pulse \


### PR DESCRIPTION
The main use case would be to set it to "host" networking mode which allows Zwift to see Wifi enabled trainers on the same network.

See this link for the Wahoo example:
https://support.wahoofitness.com/hc/en-us/articles/9211851310738-Using-KICKR-KICKR-BIKE-Wi-Fi