### PR TITLE
fix: podman compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Note you might want to disable video screenshots ([#75](https://github.com/netbr
 | ZWIFT_PASSWORD           |                         | "                                                         |
 | WINE_EXPERIMENTAL_WAYLAND|                         | If set, try to use experimental wayland support in wine 9 |
 | NETWORKING               | bridge                  | Sets the type of container networking to use.             |
-| ZWIFT_UID                | current users id        | Sets the UID that Zwift will run as                       |
-| ZWIFT_GID                | current users group id  | Sets the GID that Zwift will run as                       |
+| ZWIFT_UID                | current users id        | Sets the UID that Zwift will run as (docker only)         |
+| ZWIFT_GID                | current users group id  | Sets the GID that Zwift will run as (docker only)         |
 
 These environment variables can be used to alter the execution of the zwift bash script. 
 

--- a/zwift.sh
+++ b/zwift.sh
@@ -26,7 +26,7 @@ then
     if [[ $CONTAINER_TOOL == "podman" ]]
     then
         VGA_DEVICE_FLAG="--device=nvidia.com/gpu=all"
-    else 
+    else
         VGA_DEVICE_FLAG="--gpus all"
     fi
 else
@@ -76,7 +76,6 @@ fi
 
 ### START ###
 
-# Start the zwift container
 CONTAINER=$($CONTAINER_TOOL run \
     -d \
     --rm \
@@ -84,6 +83,8 @@ CONTAINER=$($CONTAINER_TOOL run \
     --network $NETWORKING \
     --name zwift-$USER \
     -e DISPLAY=$DISPLAY \
+    $([ "$CONTAINER_TOOL" = "podman" ] && echo '--userns=keep-id') \
+    $([ "$CONTAINER_TOOL" = "podman" ] && echo '--entrypoint /bin/setup_and_run_zwift') \
     -e ZWIFT_UID=$ZWIFT_UID \
     -e ZWIFT_GID=$ZWIFT_GID \
     -v /tmp/.X11-unix:/tmp/.X11-unix \


### PR DESCRIPTION
Fixes https://github.com/netbrain/zwift/issues/100
The workings of user namespaces in Linux elude me, so I think it's still important to get to the root causes, but at least this will restore `podman` compatibility as it was before