### PR TITLE
feat: inhibit screensaver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 ENV WINEDEBUG=fixme-all
 
-RUN dpkg --add-architecture i386 
+RUN dpkg --add-architecture i386
 
 # prerequisites
 # - wget for downloading winehq key
@@ -32,9 +32,10 @@ RUN dpkg --add-architecture i386
 # - libgl1 for GL library
 # - libvulkan1 for vulkan loader library
 # - procps for pgrep
+# - xdg-utils for xdg-screensaver
 
 RUN apt-get update
-RUN apt-get install -y wget curl sudo winbind libgl1 libvulkan1 procps gosu
+RUN apt-get install -y wget curl sudo winbind libgl1 libvulkan1 procps gosu xdg-utils
 RUN wget -qO /etc/apt/trusted.gpg.d/winehq.asc https://dl.winehq.org/wine-builds/winehq.key
 RUN DEBIAN_VERSION=${DEBIAN_VERSION} echo "deb https://dl.winehq.org/wine-builds/debian/ ${DEBIAN_VERSION} main" > /etc/apt/sources.list.d/winehq.list
 RUN apt-get update

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ zwift
 ```
 Note you might want to disable video screenshots ([#75](https://github.com/netbrain/zwift/issues/75))
 
+If dbus is available through a unix socket, the screensaver will be inhibited every 30 seconds to prevent xscreensaver or other programs listening on the bus from inhibiting the screen.
+
 ## Configuration options
 | Key                      | Default                 | Description                                               |
 |--------------------------|-------------------------|-----------------------------------------------------------|

--- a/setup_and_run_zwift.sh
+++ b/setup_and_run_zwift.sh
@@ -66,7 +66,7 @@ then
 
     # install dotnet48 for zwift
     winetricks -q dotnet48
-        
+
     # install webview 2
     wget -O webview2-setup.exe https://go.microsoft.com/fwlink/p/?LinkId=2124703
     wine webview2-setup.exe /silent /install
@@ -79,7 +79,7 @@ then
     # update game through zwift launcher
     wait_for_zwift_game_update
     wineserver -k
-    
+
     # cleanup
     rm "$ZWIFT_HOME/ZwiftSetup.exe"
     rm "$ZWIFT_HOME/webview2-setup.exe"
@@ -115,6 +115,8 @@ do
     echo "Waiting for zwift to start ..."
     sleep 1
 done
+
+[[ -n "${DBUS_SESSION_BUS_ADDRESS}" ]] && watch -n 30 xdg-screensaver reset &
 
 echo "Killing uneccesary applications"
 pkill ZwiftLauncher

--- a/zwift.sh
+++ b/zwift.sh
@@ -76,12 +76,12 @@ fi
 
 if [[ -n "$DBUS_SESSION_BUS_ADDRESS" ]]
 then
-    REGEX='^unix:path=([^,]+)'
-    [[ $DBUS_SESSION_BUS_ADDRESS =~ $REGEX ]]
+    [[ $DBUS_SESSION_BUS_ADDRESS =~ ^unix:path=([^,]+) ]]
 
-    if [[ -n "${BASH_REMATCH[1]}" ]]
+    DBUS_UNIX_SOCKET=${BASH_REMATCH[1]}
+    if [[ -n "$DBUS_UNIX_SOCKET" ]]
     then
-        DBUS_CONFIG_FLAGS="-e DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS -v ${BASH_REMATCH[1]}:${BASH_REMATCH[1]}"
+        DBUS_CONFIG_FLAGS="-e DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS -v $DBUS_UNIX_SOCKET:$DBUS_UNIX_SOCKET"
     fi
 fi
 

--- a/zwift.sh
+++ b/zwift.sh
@@ -74,6 +74,17 @@ then
     $CONTAINER_TOOL pull $IMAGE:$VERSION
 fi
 
+if [[ -n "$DBUS_SESSION_BUS_ADDRESS" ]]
+then
+    REGEX='^unix:path=([^,]+)'
+    [[ $DBUS_SESSION_BUS_ADDRESS =~ $REGEX ]]
+
+    if [[ -n "${BASH_REMATCH[1]}" ]]
+    then
+        DBUS_CONFIG_FLAGS="-e DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS -v ${BASH_REMATCH[1]}:${BASH_REMATCH[1]}"
+    fi
+fi
+
 ### START ###
 
 CONTAINER=$($CONTAINER_TOOL run \
@@ -92,6 +103,7 @@ CONTAINER=$($CONTAINER_TOOL run \
     -v zwift-$USER:/home/user/.wine/drive_c/users/user/Documents/Zwift \
     $ZWIFT_CONFIG_FLAG \
     $ZWIFT_USER_CONFIG_FLAG \
+    $DBUS_CONFIG_FLAGS \
     $VGA_DEVICE_FLAG \
     $IMAGE:$VERSION)
 


### PR DESCRIPTION
since running zwift doesn't require any keyboard/mouse input, the screensaver/screen lock, etc may be triggered in the middle.
afaik, the standard for inhibiting the screensaver is to periodically call the dbus service `org.freedesktop.ScreenSaver` with the `Inhibit` method, for example, with [`xscreensaver`](https://github.com/Zygo/xscreensaver/blob/0c43268adc2e7a932ca5427db7b18d37ef53f7ad/driver/xscreensaver-systemd.c#L41)
This is what Firefox does.
The easiest way to achieve this, is to use `xdg-screensaver reset` from the `xdg-utils` package.
I've been running this separately in another terminal each time I start `zwift`, but I think it's a good idea to add support for it for anyone who's running a dbus server.

Edit: lutris may have done something similar: https://github.com/lutris/lutris/issues/2424#issuecomment-609976923