### PR TITLE
fix: x server access

### DIFF
--- a/run_zwift.sh
+++ b/run_zwift.sh
@@ -41,6 +41,8 @@ do
     sleep 1
 done
 
+[[ -n "${DBUS_SESSION_BUS_ADDRESS}" ]] && watch -n 30 xdg-screensaver reset &
+
 echo "Killing uneccesary applications"
 pkill ZwiftLauncher
 pkill ZwiftWindowsCra

--- a/zwift.sh
+++ b/zwift.sh
@@ -123,7 +123,7 @@ then
         # Using Experimental Wayland, setup required parameters
         # To force wayland DISPLAY must be blank.
         WAYLAND_FLAGS=(
-            -e XDG_RUNTIME_DIR=/run/user/$ZWIFT_UID 
+            -e XDG_RUNTIME_DIR=/run/user/$ZWIFT_UID
             -e PULSE_SERVER=/run/user/$ZWIFT_UID/pulse/native
             -e WINE_EXPERIMENTAL_WAYLAND=1
         )
@@ -143,9 +143,9 @@ then
     # if left to the run command the directory can get the wrong permissions
     if [[ -z $(podman volume ls | grep zwift-$USER) ]]
     then
-        $CONTAINER_TOOL volume create zwift-$USER 
+        $CONTAINER_TOOL volume create zwift-$USER
     fi
-    
+
     PODMAN_FLAGS=(
         --userns keep-id:uid=$ZWIFT_UID,gid=$ZWIFT_GID
     )
@@ -162,7 +162,7 @@ CONTAINER=$($CONTAINER_TOOL run ${GENERAL_FLAGS[@]} \
 )
 
 # Allow container to connect to X, has to be set for different UID
-if [[ -z $WAYLAND_DISPLAY && $ZWIFT_UID -ne $(id -u) ]]
+if [[ -z $WAYLAND_DISPLAY ]]
 then
     xhost +local:$($CONTAINER_TOOL inspect --format='{{ .Config.Hostname  }}' $CONTAINER)
 fi


### PR DESCRIPTION
the latest changes added an additional check to the call to `xhost`, this prevented the container from being able to access xserver on my host.
also, the screensaver inhibit code was lost in https://github.com/netbrain/zwift/pull/108, I returned it here