### PR TITLE
fix: watch requires a term to be set

### DIFF
--- a/run_zwift.sh
+++ b/run_zwift.sh
@@ -41,7 +41,7 @@ do
     sleep 1
 done
 
-[[ -n "${DBUS_SESSION_BUS_ADDRESS}" ]] && watch -n 30 xdg-screensaver reset &
+[[ -n "${DBUS_SESSION_BUS_ADDRESS}" ]] && while true; do sleep 30; xdg-screensaver reset; done &
 
 echo "Killing uneccesary applications"
 pkill ZwiftLauncher


### PR DESCRIPTION
hm... somewhere along the way, the inhibit functionality broke ^^;;
turns out that the `watch` command needs a terminal connected to it, and the `TERM` env variable to be set (see https://unix.stackexchange.com/questions/17999/how-can-i-run-watch-as-a-background-job).
not sure why it worked before all the refactoring honestly... but this should be a better approach anyways I think