### PR TITLE
fix(xauth): add hostname to container

### DIFF
--- a/zwift.sh
+++ b/zwift.sh
@@ -140,12 +140,14 @@ then
     else
 
         WAYLAND_FLAGS=(
+            --hostname $HOSTNAME
             -e PULSE_SERVER=/run/user/$ZWIFT_UID/pulse/native
             -v $XAUTHORITY:$(echo $XAUTHORITY | sed 's/'$UID'/'$ZWIFT_UID'/')
         )
     fi
 else
     X11_FLAGS=(
+        --hostname $HOSTNAME
         -v $XAUTHORITY:$(echo $XAUTHORITY | sed 's/'$UID'/'$ZWIFT_UID'/')
     )
 fi


### PR DESCRIPTION
turns out, hostname is required to match in order for xauth to work after all, sorry for the continued fixes, I think this is the last one 😅