### PR TITLE
correct paths for `$USER-config`

### DIFF
--- a/zwift.sh
+++ b/zwift.sh
@@ -65,8 +65,8 @@ fi
 # Check for $USER specific zwift configuration, sourced here and passed on to container aswell
 if [[ -f "$HOME/.config/zwift/$USER-config" ]]
 then
-    ZWIFT_USER_CONFIG_FLAG="--env-file $HOME/.config/zwift/config"
-    source $HOME/.config/zwift/config
+    ZWIFT_USER_CONFIG_FLAG="--env-file $HOME/.config/zwift/$USER-config"
+    source $HOME/.config/zwift/$USER-config
 fi
 
 ########################################


### PR DESCRIPTION
Noticed this small omission while troubleshooting #139, it looks like you intended to set `ZWIFT_USER_CONFIG_FLAG` and source from `$HOME/.config/zwift/$USER-config`, not a second time from `$HOME/.config/zwift/config`