### PR TITLE
fix(screensaver): detect xscreensaver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,9 +40,10 @@ RUN dpkg --add-architecture i386
 # - libvulkan1 for vulkan loader library
 # - procps for pgrep
 # - xdg-utils for xdg-screensaver
+# - xscreensaver for xscreensaver-command, used by xdg-screensaver to inhibit xscreensaver
 
 RUN apt-get update
-RUN apt-get install -y wget curl sudo winbind libgl1 libvulkan1 procps gosu xdg-utils
+RUN apt-get install -y wget curl sudo winbind libgl1 libvulkan1 procps gosu xdg-utils xscreensaver
 RUN wget -qO /etc/apt/trusted.gpg.d/winehq.asc https://dl.winehq.org/wine-builds/winehq.key
 RUN DEBIAN_VERSION=${DEBIAN_VERSION} echo "deb https://dl.winehq.org/wine-builds/debian/ ${DEBIAN_VERSION} main" > /etc/apt/sources.list.d/winehq.list
 RUN apt-get update


### PR DESCRIPTION
the ever evolving battle against screensavers (or in favor of screensavers, depending how you look at it) rages on.
turns out that I was missing `xscreensaver-command` which is [used by xdg-screensaver](https://gitlab.freedesktop.org/xdg/xdg-utils/-/blob/v1.1.3/scripts/xdg-screensaver.in?ref_type=tags#L885) to detect and inhibit xscreensaver.
this explains why I was still getting screensavers while zwift was open, whenever youtube would not be playing on my other screen. oops 😅
I think  a few more environment variables might be needed to make available to detect other screensavers or power management schemes in gnome/kde, but I don't use those systems so I couldn't test them. I could try to add those based on the contents of `xdg-screensaver` though