### PR TITLE
Update to Support zwo files better and other Minor Fixes.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,6 @@ ARG WINE_VERSION="=9.9~trixie-1"
 
 ARG WINETRICKS_VERSION=20240105
 ARG DEBIAN_VERSION
-ENV NVIDIA_VISIBLE_DEVICES=all
-ENV NVIDIA_DRIVER_CAPABILITIES=all
-ENV WINEDEBUG=fixme-all
 
 RUN dpkg --add-architecture i386
 
@@ -71,6 +68,11 @@ RUN adduser --disabled-password --gecos ''  user && \
   echo '%SUDO ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 FROM wine-base
+
+# Moved Environments into wine-base build part.
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=all
+ENV WINEDEBUG=fixme-all
 
 LABEL org.opencontainers.image.authors="Kim Eik <kim@heldig.org>"
 LABEL org.opencontainers.image.title="netbrain/zwift"

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,19 +82,19 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /bin/entrypoint
-RUN chmod +x /bin/entrypoint
+RUN chmod +rx /bin/entrypoint
 
 COPY update_zwift.sh /bin/update_zwift.sh
-RUN chmod +x /bin/update_zwift.sh
+RUN chmod +rx /bin/update_zwift.sh
 
 COPY run_zwift.sh /bin/run_zwift.sh
-RUN chmod +x /bin/run_zwift.sh
+RUN chmod +rx /bin/run_zwift.sh
 
 COPY zwift-auth.sh /bin/zwift-auth
-RUN chmod +x /bin/zwift-auth
+RUN chmod +rx /bin/zwift-auth
 
 COPY --from=build-runfromprocess /usr/src/target/x86_64-pc-windows-gnu/release/runfromprocess-rs.exe /bin/runfromprocess-rs.exe
-RUN chmod +x /bin/runfromprocess-rs.exe
+RUN chmod +rx /bin/runfromprocess-rs.exe
 
 ENTRYPOINT ["entrypoint"]
 CMD [$@]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG DEBIAN_VERSION=bookworm
+ARG DEBIAN_VERSION=trixie
 
 FROM rust:1.72 as build-runfromprocess
 
@@ -14,6 +14,7 @@ RUN git clone https://github.com/quietvoid/runfromprocess-rs .
 RUN cargo build --target x86_64-pc-windows-gnu --release
 
 FROM debian:${DEBIAN_VERSION}-slim as wine-base
+ARG DEBIAN_VERSION
 
 # As at May 2024 Wayland Native works wine 9.9 or later:
 #    WINE_BRANCH="devel"
@@ -21,10 +22,8 @@ FROM debian:${DEBIAN_VERSION}-slim as wine-base
 # make sure to add "=" to the start, comment out for latest
 #    WINE_VERSION="=9.9~bookworm-1"
 ARG WINE_BRANCH="devel"
-ARG WINE_VERSION="=9.9~bookworm-1"
-
+ARG WINE_VERSION="=9.9~${DEBIAN_VERSION}-1"
 ARG WINETRICKS_VERSION=20240105
-ARG DEBIAN_VERSION
 
 RUN dpkg --add-architecture i386
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG DEBIAN_VERSION=trixie
+ARG DEBIAN_VERSION=bookworm
 
 FROM rust:1.72 as build-runfromprocess
 
@@ -19,9 +19,9 @@ FROM debian:${DEBIAN_VERSION}-slim as wine-base
 #    WINE_BRANCH="devel"
 # For Specific version fix add WINE_VERSION,
 # make sure to add "=" to the start, comment out for latest
-#    WINE_VERSION="=9.9~trixie-1"
+#    WINE_VERSION="=9.9~bookworm-1"
 ARG WINE_BRANCH="devel"
-ARG WINE_VERSION="=9.9~trixie-1"
+ARG WINE_VERSION="=9.9~bookworm-1"
 
 ARG WINETRICKS_VERSION=20240105
 ARG DEBIAN_VERSION

--- a/README.md
+++ b/README.md
@@ -145,10 +145,14 @@ You can map the Zwift Workout folder using the environment variable ZWIFT_WORKOU
 
 You can add this variable into $HOME/.config/zwift/config or $HOME/.config/zwift/$USER-config.
 
+The workouts folder will contain subvolders e.g. $HOME/.config/zwift/workouts/393938.  The number is your internal zwift id and you store you zwo files in the relevant folder.  There will usually be only one ID, however if you have multiple zwift login's it may show one subfolder for each, to find the ID you can use the following link: 
+
+Webpage for finding internal ID: https://www.virtualonlinecycling.com/p/zwiftid.html
+
 NOTES: 
 - Any workouts created already will be copied into this folder on first start
 - To add a new workout just copy the zwo file to this directory
-- Deleting files from the directory will not delete them, they will be re-added when re-starting zwift, you must delete from the zwift menu.
+- Deleting files from the directory will not delete them, they will be re-added when re-starting zwift, you must delete from the zwift menu
 
 ## How can I build the image myself?
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ Note: This will be loaded by zwift.sh in cleartext as environment variables into
 
 > :warning: **Do Not Quote the variables or add spaces**: The ID and Password are read as raw format so if you put ZWIFT_PASSWORD="password" it tries to use "password" and not just password, same for ''.  In addition do not add a space to the end of the line it will be sent as part of the pasword or username. This applies to ZWIFT_USERNAME and ZWIFT_PASSWORD. 
 
+NOTE: You can also add other environment variable from the table to make starting easier:
+```
+ZWIFT_USERNAME=username
+ZWIFT_PASSWORD=password
+
+ZWIFT_WORKOUT_DIR=~/.config/zwift/workouts
+WINE_EXPERIMENTAL_WAYLAND=1
+```
+
+
 ## Podman Support
 
 When running Zwift with podman, the user and group in the container is 1000 (user). To access the resources on the host we need to map the container id's 1000 to the host id's using uidmap and gidmap.  

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you find this image useful, then feel free add [me on zwift](https://www.zwif
 
 ## Prerequisites
 - [Docker](https://docs.docker.com/get-docker) or [Podman](https://podman.io/getting-started/installation)
-- [nvidia-container-toolkit](https://github.com/NVIDIA/nvidia-docker) if you have nvidia proprietary driver
+- [nvidia-container-toolkit](https://github.com/NVIDIA/nvidia-container-toolkit) if you have nvidia proprietary driver
 - ATI, Intel and Nouveau drivers should work out of the box
 
 > :warning: **Podman Support 4.3 and Later.**: Podman before 4.3 does not support --userns=keep-id:uid=xxx,gid=xxx and will not start correctly, this impacts Ubuntu 22.04 and related builds such as PopOS 22.04. See Podman Section below.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ If dbus is available through a unix socket, the screensaver will be inhibited ev
 | CONTAINER_TOOL           |                         | Defaults to podman if installed, else docker              |
 | ZWIFT_USERNAME           |                         | If set, try to login to zwift automatically               |
 | ZWIFT_PASSWORD           |                         | "                                                         |
+| ZWIFT_WORKOUT_DIR        |                         | Set the Workout Directory locaiton                        |
 | WINE_EXPERIMENTAL_WAYLAND|                         | If set, try to use experimental wayland support in wine 9 |
 | NETWORKING               | bridge                  | Sets the type of container networking to use.             |
 | ZWIFT_UID                | current users id        | Sets the UID that Zwift will run as (docker only)         |
@@ -128,31 +129,14 @@ For example, your Wahoo Kickr and Apple Watch conect to the Zwift Companion app 
 iPhone; then the Companion app connects over wifi to your PC running Zwift.
 
 ## How can I add custom .zwo files?
+You can map the Zwift Workout folder using the environment variable ZWIFT_WORKOUT_DIR, for example if your workout directory is in $HOME/zwift_workouts then you would provide the environment variable, you can add this variable into $HOME/.config/zwift/config or $HOME/.config/zwift/$USER-config.
 
-The folder's name that receives .zwo files is dynamic based on your user's numeric ID. This example works considering you have a single user in the same docker volume.
-After you've downloaded/created your .zwo files use the following script to copy it to the correct folder:
+```ZWIFT_WORKOUT_DIR=$HOME/zwift_workouts```
 
-```console
-# docker
-docker run -v zwift-$USER:/data --name zwift-copy-op busybox ls /data/Workouts | xargs -I {} docker cp my-workouts-file.zwo zwift-copy-op:/data/Workouts/{}
-docker rm zwift-copy-op
-
-#podman
-@TBD
-```
-
-If you have multiple users at the same volume you might want to find out which IDs exist in your setup and map the ID for each user to copy correctly to the corresponding user.
-An example of this would be:
-
-```console
-# docker
-docker run -v zwift-$USER:/data --name zwift-copy-op busybox true
-docker cp my-workouts-file.zwo zwift-copy-op:/data/Workouts/1234
-docker rm zwift-copy-op
-
-#podman
-@TBD
-```
+NOTES: 
+- Any workouts created already will be copied into this folder on first start
+- To add a new workout just copy the zwo file to this directory
+- Deleting files from the directory will not delete them, they will be re-added when re-starting zwift, you must delete from the zwift menu.
 
 ## How can I build the image myself?
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If dbus is available through a unix socket, the screensaver will be inhibited ev
 | CONTAINER_TOOL           |                         | Defaults to podman if installed, else docker              |
 | ZWIFT_USERNAME           |                         | If set, try to login to zwift automatically               |
 | ZWIFT_PASSWORD           |                         | "                                                         |
-| ZWIFT_WORKOUT_DIR        |                         | Set the Workout Directory locaiton                        |
+| ZWIFT_WORKOUT_DIR        |                         | Set the workouts directory location                       |
 | WINE_EXPERIMENTAL_WAYLAND|                         | If set, try to use experimental wayland support in wine 9 |
 | NETWORKING               | bridge                  | Sets the type of container networking to use.             |
 | ZWIFT_UID                | current users id        | Sets the UID that Zwift will run as (docker only)         |
@@ -129,9 +129,11 @@ For example, your Wahoo Kickr and Apple Watch conect to the Zwift Companion app 
 iPhone; then the Companion app connects over wifi to your PC running Zwift.
 
 ## How can I add custom .zwo files?
-You can map the Zwift Workout folder using the environment variable ZWIFT_WORKOUT_DIR, for example if your workout directory is in $HOME/zwift_workouts then you would provide the environment variable, you can add this variable into $HOME/.config/zwift/config or $HOME/.config/zwift/$USER-config.
+You can map the Zwift Workout folder using the environment variable ZWIFT_WORKOUT_DIR, for example if your workout directory is in $HOME/zwift_workouts then you would provide the environment variable
 
 ```ZWIFT_WORKOUT_DIR=$HOME/zwift_workouts```
+
+You can add this variable into $HOME/.config/zwift/config or $HOME/.config/zwift/$USER-config.
 
 NOTES: 
 - Any workouts created already will be copied into this folder on first start

--- a/bin/build-image.sh
+++ b/bin/build-image.sh
@@ -29,7 +29,6 @@ fi
 GENERAL_FLAGS=(
     -it
     --privileged
-    --ipc host
     --network bridge
     --name zwift
     --security-opt label=disable
@@ -52,10 +51,11 @@ else
 fi
 
 # Initiate podman Volume with correct permissions
-if [[ "$CONTAINER_TOOL" == "podman" ]]
-then   
+if [[ "$CONTAINER_TOOL" == "podman" ]]; then 
+    # Add ipc host to deal with an SHM issue on some machines.
     PODMAN_FLAGS=(
         --userns keep-id:uid=$ZWIFT_UID,gid=$ZWIFT_GID
+        --ipc host 
     )
 fi
 

--- a/bin/build-image.sh
+++ b/bin/build-image.sh
@@ -29,6 +29,7 @@ fi
 GENERAL_FLAGS=(
     -it
     --privileged
+    --ipc host
     --network bridge
     --name zwift
     --security-opt label=disable

--- a/zwift.sh
+++ b/zwift.sh
@@ -41,8 +41,7 @@ msgbox() {
 # More ease of use starting from desktop icon.
 
 # Check for other zwift configuration, sourced here and passed on to container aswell
-if [[ -f "$HOME/.config/zwift/config" ]]
-then
+if [[ -f "$HOME/.config/zwift/config" ]]; then
     ZWIFT_CONFIG_FLAG="--env-file $HOME/.config/zwift/config"
     source $HOME/.config/zwift/config
 fi
@@ -52,6 +51,11 @@ if [[ -f "$HOME/.config/zwift/$USER-config" ]]
 then
     ZWIFT_USER_CONFIG_FLAG="--env-file $HOME/.config/zwift/$USER-config"
     source $HOME/.config/zwift/$USER-config
+fi
+
+# If a workout directory is specified then map to that directory.
+if [[ ! -z $ZWIFT_WORKOUT_DIR ]]; then
+    ZWIFT_WORKOUT_VOL="-v $ZWIFT_WORKOUT_DIR:/home/user/.wine/drive_c/users/user/Documents/Zwift/Workouts"
 fi
 
 ########################################
@@ -249,6 +253,7 @@ fi
 CONTAINER=$($CONTAINER_TOOL run ${GENERAL_FLAGS[@]} \
         $ZWIFT_CONFIG_FLAG \
         $ZWIFT_USER_CONFIG_FLAG \
+        $ZWIFT_WORKOUT_VOL \
         $VGA_DEVICE_FLAG \
         ${DBUS_CONFIG_FLAGS[@]} \
         ${WM_FLAGS[@]} \


### PR DESCRIPTION
Some additional fixes below, this requires a rebuild of the docker.

- #89 Added the abiltiy to map a directory for custom zwo files to a local directory using an environment parameter, updated readme.
- Minor Fix to Docker to make the entrypoint and other files rx by default (from just x)
- Minor Fix for Podman Build to set ipc host temporarily, can cause failures on laptops
- #147 - Attempt to fix issue by moving the Enviornment Variables for NVIDIA
- Update Readme to point to new Nvidia-container-toolkit not the deprecated one

