### PR TITLE
fix: do not require gamemode installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,10 @@ RUN dpkg --add-architecture i386
 # - procps for pgrep
 # - gamemode for freedesktop screensaver inhibit
 # - xdg-utils seems to be a dependency of wayland
+# - xscreensaver provides xscreensaver-command which is used by xdg-screensaver to inhibit xscreensaver if present in the current x session
 
 RUN apt-get update
-RUN apt-get install -y wget curl sudo winbind libgl1 libvulkan1 procps gosu gamemode xdg-utils
+RUN apt-get install -y wget curl sudo winbind libgl1 libvulkan1 procps gosu gamemode xdg-utils xscreensaver
 RUN wget -qO /etc/apt/trusted.gpg.d/winehq.asc https://dl.winehq.org/wine-builds/winehq.key
 RUN DEBIAN_VERSION=${DEBIAN_VERSION} echo "deb https://dl.winehq.org/wine-builds/debian/ ${DEBIAN_VERSION} main" > /etc/apt/sources.list.d/winehq.list
 RUN apt-get update

--- a/run_zwift.sh
+++ b/run_zwift.sh
@@ -33,6 +33,8 @@ do
     sleep 1
 done
 
+[[ -n "${DBUS_SESSION_BUS_ADDRESS}" ]] && while true; do sleep 30; xdg-screensaver reset; done &
+
 echo "Killing uneccesary applications"
 pkill ZwiftLauncher
 pkill ZwiftWindowsCra

--- a/run_zwift.sh
+++ b/run_zwift.sh
@@ -33,7 +33,7 @@ do
     sleep 1
 done
 
-[[ -n "${DBUS_SESSION_BUS_ADDRESS}" ]] && while true; do sleep 30; xdg-screensaver reset; done &
+while true; do sleep 30; xdg-screensaver reset; done &
 
 echo "Killing uneccesary applications"
 pkill ZwiftLauncher


### PR DESCRIPTION
Unfortunately, screensaver shenanigans are not over yet...
When I tested `gamemode` I used my Slackware desktop PC, and I had installed `gamemode` on in to test it out. Earlier when I tried to run zwift on my Arch Linux laptop, unfortunately I encountered the screensaver and monitor power off issue again...
Turns out that `gamemode` needs to be installed on the host system for it to work. In the arch linux laptop, it was missing.
When it is missing, you can see an error:

```
+ /usr/games/gamemoderun wineserver -w
GameMode ERROR: D-Bus error: Could not call method 'RegisterGame' on 'com.feralinteractive.GameMode': The name is not activatable
gamemodeauto: D-Bus error: Could not call method 'RegisterGame' on 'com.feralinteractive.GameMode': The name is not activatable
GameMode ERROR: D-Bus error: Could not call method 'UnregisterGame' on 'com.feralinteractive.GameMode': The name is not activatable
gamemodeauto: D-Bus error: Could not call method 'UnregisterGame' on 'com.feralinteractive.GameMode': The name is not activatable
```

That is because `usr/share/dbus-1/services/com.feralinteractive.GameMode.service` is missing. In this case, the screensaver `Inhibit` method will not be called, and the screen will go on to be activated. If `gamemode` is installed in the host system, this will work fine though.

The aim of this PR is to try to have the best of all worlds, we do not require `gamemode` to be available on the host system, and do the heartbeat like we used to... I don't think those will conflict now that I think about it, since they use different mechanisms to inhibit the screensaver. An alternative might be to mention that `gamemode` needs to be available on the host system to work...