### PR TITLE
zwift-auth: fix invalid variable in latest curl

### DIFF
--- a/zwift-auth.sh
+++ b/zwift-auth.sh
@@ -25,7 +25,7 @@ AUTHENTICATE_URL=$(curl -sSL --get --cookie "$COOKIE" --cookie-jar "$COOKIE" \
 ACCESS_CODE=$(curl -sS --cookie "$COOKIE" --cookie-jar "$COOKIE" \
   --data-urlencode "username=$ZWIFT_USERNAME" \
   --data-urlencode "password=$ZWIFT_PASSWORD" \
-  --write-out "%{REDIRECT_URL}" \
+  --write-out "%{redirect_url}" \
   "$AUTHENTICATE_URL" | grep -oP "code=\K.+$")
 
 AUTH_TOKEN_JSON=$(curl -sS --cookie "$COOKIE" --cookie-jar "$COOKIE" \


### PR DESCRIPTION
Starting from `curl` version `8.9.0`, `REDIRECT_URL` in caps is not recognized.
Currently the latest `netbrain/zwift` image is still using `curl` version `8.8.0` so it's still working but if it were built from scratch, it would get an updated `curl`.