### PR TITLE
Make install script work with restrictive umask

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -9,7 +9,7 @@ read -p "Press enter to continue"
 
 mkdir -p /usr/local/bin
 curl -s -o /usr/local/bin/zwift https://raw.githubusercontent.com/netbrain/zwift/master/zwift.sh
-chmod +x /usr/local/bin/zwift
+chmod u=rwx,go=rx /usr/local/bin/zwift
 
 mkdir -p /usr/local/share/icons/hicolor/scalable/apps
 curl -s -o /usr/local/share/icons/hicolor/scalable/apps/zwift.svg https://raw.githubusercontent.com/netbrain/zwift/master/assets/hicolor/scalable/apps/Zwift%20Logogram.svg


### PR DESCRIPTION
If a user has set `umask 077` or other umasks more restrictive than `022` (the default on many distros), the install script will not work because it only enables the execute bit on `/usr/local/bin/zwift` for users for whom the file is already readable. This makes it set all permissions, rather than modifying the existing permissions, to 0755 (read/write/execute for `root`, read/execute for others).