### PR TITLE
support CONTAINER_TOOL values with spaces

### DIFF
--- a/zwift.sh
+++ b/zwift.sh
@@ -21,7 +21,7 @@ msgbox() {
             echo -n -e "${RED}${BOLD}${UNDERLINE}Question - $MSG (y/n)${NC}"
             read $TIMEOUT -n 1 -p " " yn
             echo
-            case $yn in 
+            case $yn in
                 y) return 0;;
                 n) return 1;;
                 *) return 5;;
@@ -69,7 +69,7 @@ ZWIFT_UID=${ZWIFT_UID:-$(id -u)}
 ZWIFT_GID=${ZWIFT_GID:-$(id -g)}
 
 # CONTAINER_TOOL, Use podman if available
-if [ ! $CONTAINER_TOOL ]; then
+if [ -z "$CONTAINER_TOOL" ]; then
     if [ -x "$(command -v podman)" ]; then
         CONTAINER_TOOL=podman
     else
@@ -94,7 +94,7 @@ if [ -n "${ZWIFT_USERNAME}" -a -z "${ZWIFT_PASSWORD}" -a -x "$(command -v secret
     fi
 fi
 
-if [ $CONTAINER_TOOL == "podman" ]; then
+if [ "$CONTAINER_TOOL" == "podman" ]; then
     # Podman has to use container id 1000
     # Local user is mapped to the container id
     LOCAL_UID=$ZWIFT_UID
@@ -129,7 +129,7 @@ esac
 # Verify which system we are using for wayland and some checks.
 if [ "$WINDOW_MANAGER" = "Wayland" ]; then
     # System is using wayland or xwayland.
-    if [ -z $WINE_EXPERIMENTAL_WAYLAND ]; then 
+    if [ -z $WINE_EXPERIMENTAL_WAYLAND ]; then
         WINDOW_MANAGER="XWayland"
     else
         WINDOW_MANAGER="Wayland"
@@ -224,7 +224,7 @@ fi
 if [[ $ZWIFT_FG -eq "1" ]]
 then
     ZWIFT_FG_FLAG=(-it) # run in fg
-else 
+else
     ZWIFT_FG_FLAG=(-d) # run in bg
 fi
 
@@ -260,7 +260,7 @@ if [ $WINDOW_MANAGER == "XOrg" ]; then
 fi
 
 # Initiate podman Volume with correct permissions
-if [ $CONTAINER_TOOL == "podman" ]; then
+if [ "$CONTAINER_TOOL" == "podman" ]; then
     # Create a volume if not already exists, this is done now as
     # if left to the run command the directory can get the wrong permissions
     if [[ -z $(podman volume ls | grep zwift-$USER) ]]; then


### PR DESCRIPTION
it's common to need to run `docker` with elevated privileges (in my case, `docker` is [rootless](https://docs.docker.com/engine/security/rootless/)), so allow prefixing `CONTAINER_TOOL` with `sudo`.

#### Before

```
$ CONTAINER_TOOL="sudo docker" zwift
/usr/local/bin/zwift: line 72: [: sudo: unary operator expected
/usr/local/bin/zwift: line 80: [: too many arguments
You are running latest zwift.sh 👏
[sudo] password for jamison: 
latest: Pulling from netbrain/zwift
Digest: sha256:c158da7fb55b1b1c21a6633e10914726eb8dc8ab0755ce1bc80b74f61cd8cafb
Status: Image is up to date for netbrain/zwift:latest
docker.io/netbrain/zwift:latest
/usr/local/bin/zwift: line 246: [: too many arguments

```

these are shellcheck lint warnings anyways.

```text
In /src/zwift.sh line 72:
if [ ! $CONTAINER_TOOL ]; then
       ^-------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
if [ ! "$CONTAINER_TOOL" ]; then


In /src/zwift.sh line 80:
if [ $CONTAINER_TOOL == "podman" ]; then
     ^-------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
if [ "$CONTAINER_TOOL" == "podman" ]; then


In /src/zwift.sh line 246:
if [ $CONTAINER_TOOL == "podman" ]; then
     ^-------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
if [ "$CONTAINER_TOOL" == "podman" ]; then

```