### PR TITLE
Install: Allow for local user install

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1,23 +1,49 @@
 #!/usr/bin/env bash
 
-if [ ! $(id -u) = 0 ]; then
-    echo "Please run as root"
-    exit 1
+if [[ $EUID -eq 0 ]]; then
+  root_bin=/usr/local/bin
+  root_share=/usr/local/share
+else
+  # user install
+  root_bin="${XDG_BIN_HOME:-$HOME/.local/bin}"
+  root_share="${XDG_DATA_HOME:-$HOME/.local/share}"
 fi
-echo "This will install zwift.sh into /usr/local/bin"
-read -p "Press enter to continue"
 
-mkdir -p /usr/local/bin
-curl -s -o /usr/local/bin/zwift https://raw.githubusercontent.com/netbrain/zwift/master/zwift.sh
-chmod u=rwx,go=rx /usr/local/bin/zwift
+echo "Installing zwift to:"
+echo "  binaries → ${root_bin}"
+echo "  data     → ${root_share}"
 
-mkdir -p /usr/local/share/icons/hicolor/scalable/apps
-curl -s -o /usr/local/share/icons/hicolor/scalable/apps/zwift.svg https://raw.githubusercontent.com/netbrain/zwift/master/assets/hicolor/scalable/apps/Zwift%20Logogram.svg
+read -p "Press ENTER to continue or Ctrl-C to abort…"
 
-mkdir -p /usr/local/share/applications
-curl -s -o /usr/local/share/applications/Zwift.desktop https://raw.githubusercontent.com/netbrain/zwift/master/assets/Zwift.desktop
+# create dirs
+mkdir -p "${root_bin}"
+mkdir -p "${root_share}/icons/hicolor/scalable/apps"
+mkdir -p "${root_share}/applications"
+
+# download
+curl -fsSL \
+  -o "${root_bin}/zwift" \
+  https://raw.githubusercontent.com/netbrain/zwift/master/zwift.sh
+chmod 755 "$root_bin/zwift"
+
+curl -fsSL \
+  -o "${root_share}/icons/hicolor/scalable/apps/zwift.svg" \
+  https://raw.githubusercontent.com/netbrain/zwift/master/assets/hicolor/scalable/apps/Zwift%20Logogram.svg
+
+curl -fsSL \
+  -o "${root_share}/applications/Zwift.desktop" \
+  https://raw.githubusercontent.com/netbrain/zwift/master/assets/Zwift.desktop
 
 
-if [ "$(echo $PATH | grep /usr/local/bin)" = "" ]; then
-    echo "WARNING: Could not find /usr/local/bin on the \$PATH, you might need to add it."
+# warn if bin dir not in PATH
+if ! case ":$PATH:" in
+      *":$root_bin:"*) true  ;;
+      *)               false ;;
+    esac; then
+  cat <<WARN
+Warning: $root_bin is not in your PATH.
+You may need to add it to your PATH for the zwift command to work
+WARN
 fi
+
+echo "Done!"


### PR DESCRIPTION
Allows for installing the zwift scripts to the local directory so it works in read-only systems such as the steamdeck and will allow better allow for non root users to install this

Tested on my steamdeck 

This should maintain the current functionality where it installs to /usr/local/ if the script is ran as root but dont have something i can test with