### PR TITLE
#210 - Update run_zwift.sh so it does not exit early if ZwiftLauncher has already exited

### DIFF
--- a/run_zwift.sh
+++ b/run_zwift.sh
@@ -34,7 +34,10 @@ do
 done
 
 echo "Killing uneccesary applications"
-pkill ZwiftLauncher
+# ZwiftLauncher can exit on it's own before getting this far, so try to kill it
+# and then always return 0 so the script does not exit non 0 here and cause the
+# container to exit.  See https://github.com/netbrain/zwift/issues/210
+pkill ZwiftLauncher || true
 pkill ZwiftWindowsCra
 pkill -f MicrosoftEdgeUpdate
 


### PR DESCRIPTION
This change accounts for `ZwiftLauncher` having already exited before `pkill ZwiftLauncher` runs and resolves #210.