### PR TITLE
fix: ZWIFT_PROFILE_DIR for podman

### DIFF
--- a/zwift.sh
+++ b/zwift.sh
@@ -70,7 +70,7 @@ fi
 
 if [[ ! -z $ZWIFT_PROFILE_DIR ]]; then
     ZWIFT_PROFILE_DEST="/home/user/.wine/drive_c/Program\ Files\ \(x86\)/Zwift/data/configs"
-    ZWIFT_PROFILE_VOL="--mount dst=$ZWIFT_PROFILE_DEST,volume-opt=device=$ZWIFT_PROFILE_DIR,type=volume,volume-driver=local,volume-opt=type=none,volume-opt=o=bind"
+    ZWIFT_PROFILE_VOL="--mount dst=$ZWIFT_PROFILE_DEST,volume-opt=device=$ZWIFT_PROFILE_DIR,type=volume,volume-opt=type=none,volume-opt=o=bind"
 fi
 
 ########################################


### PR DESCRIPTION
`volume-driver=local` is useful for when you're running Docker in a container (e.g. Docker Desktop), but that's only relevant when using a non-Linux host, which obviously isn't the case for this project. Removing this option works for Docker and Podman, I tested locally (sorry for not testing with both initially).