### PR TITLE
Use more secure container flags

### DIFF
--- a/.github/workflows/zwift_build_from_scratch.yaml
+++ b/.github/workflows/zwift_build_from_scratch.yaml
@@ -36,8 +36,8 @@ jobs:
           docker build -t netbrain/zwift:build .
           xhost +
           docker run --name zwift \
-                  --privileged \
                   -e DISPLAY=$DISPLAY \
+                  -e CONTAINER=docker \
                   --device /dev/dri \
                   -v /tmp:/tmp \
                   netbrain/zwift:build

--- a/.github/workflows/zwift_build_matrix.yaml
+++ b/.github/workflows/zwift_build_matrix.yaml
@@ -37,8 +37,8 @@ jobs:
             -t netbrain/zwift:build .
           xhost +
           docker run --name zwift \
-                  --privileged \
                   -e DISPLAY=$DISPLAY \
+                  -e CONTAINER=docker \
                   --device /dev/dri \
                   -v /tmp:/tmp \
                   netbrain/zwift:build

--- a/.github/workflows/zwift_updater.yaml
+++ b/.github/workflows/zwift_updater.yaml
@@ -39,8 +39,8 @@ jobs:
           export DISPLAY=:99
           xhost +
           docker run --name zwift \
-                  --privileged \
                   -e DISPLAY=$DISPLAY \
+                  -e CONTAINER=docker \
                   --device /dev/dri \
                   -v /tmp:/tmp \
                   netbrain/zwift:latest update

--- a/README.md
+++ b/README.md
@@ -44,32 +44,33 @@ If dbus is available through a unix socket, the screensaver will be inhibited ev
 
 ## Configuration options
 
-| Key                       | Default                 | Description                                                |
-|---------------------------|-------------------------|------------------------------------------------------------|
-| USER                      | $USER                   | Used in creating the zwift volume `zwift-$USER`            |
-| IMAGE                     | docker.io/netbrain/zwift| The image to use                                           |
-| VERSION                   | latest                  | The image version/tag to use                               |
-| DONT_CHECK                |                         | If set, don't check for updated zwift.sh                   |
-| DONT_PULL                 |                         | If set, don't pull for new image version                   |
-| DRYRUN                    |                         | If set, print the full container run command and exit      |
-| INTERACTIVE               |                         | If set, force -it and use --entrypoint bash for debugging  |
-| CONTAINER_TOOL            |                         | Defaults to podman if installed, else docker               |
-| CONTAINER_EXTRA_ARGS      |                         | Extra args passed to docker/podman (--cpus=1.5)            |
-| ZWIFT_USERNAME            |                         | If set, try to login to zwift automatically                |
-| ZWIFT_PASSWORD            |                         | "                                                          |
-| ZWIFT_WORKOUT_DIR         |                         | Set the workouts directory location                        |
-| ZWIFT_ACTIVITY_DIR        |                         | Set the activities directory location                      |
-| ZWIFT_LOG_DIR             |                         | Set the logs directory location                            |
-| ZWIFT_OVERRIDE_GRAPHICS   |                         | If set, override the specified zwift graphics profile      |
-| ZWIFT_OVERRIDE_RESOLUTION |                         | If set, change game resolution (2560x1440, 3840x2160, ...) |
-| ZWIFT_FG                  |                         | If set, run the process in fg instead of bg (-d)           |
-| ZWIFT_NO_GAMEMODE         |                         | If set, don't run gamemode                                 |
-| WINE_EXPERIMENTAL_WAYLAND |                         | If set, try to use experimental wayland support in wine 9  |
-| NETWORKING                | bridge                  | Sets the type of container networking to use.              |
-| ZWIFT_UID                 | current users id        | Sets the UID that Zwift will run as (docker only)          |
-| ZWIFT_GID                 | current users group id  | Sets the GID that Zwift will run as (docker only)          |
-| DEBUG                     |                         | If set enabled debug of zwift script "set -x"              |
-| VGA_DEVICE_FLAG           |                         | Override GPU/device flags for container (--gpus=all)       |
+| Key                       | Default                 | Description                                                                                                                           |
+|---------------------------|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| USER                      | $USER                   | Used in creating the zwift volume `zwift-$USER`                                                                                       |
+| IMAGE                     | docker.io/netbrain/zwift| The image to use                                                                                                                      |
+| VERSION                   | latest                  | The image version/tag to use                                                                                                          |
+| DONT_CHECK                |                         | If set, don't check for updated zwift.sh                                                                                              |
+| DONT_PULL                 |                         | If set, don't pull for new image version                                                                                              |
+| DRYRUN                    |                         | If set, print the full container run command and exit                                                                                 |
+| INTERACTIVE               |                         | If set, force -it and use --entrypoint bash for debugging                                                                             |
+| CONTAINER_TOOL            |                         | Defaults to podman if installed, else docker                                                                                          |
+| CONTAINER_EXTRA_ARGS      |                         | Extra args passed to docker/podman (--cpus=1.5)                                                                                       |
+| ZWIFT_USERNAME            |                         | If set, try to login to zwift automatically                                                                                           |
+| ZWIFT_PASSWORD            |                         | "                                                                                                                                     |
+| ZWIFT_WORKOUT_DIR         |                         | Set the workouts directory location                                                                                                   |
+| ZWIFT_ACTIVITY_DIR        |                         | Set the activities directory location                                                                                                 |
+| ZWIFT_LOG_DIR             |                         | Set the logs directory location                                                                                                       |
+| ZWIFT_OVERRIDE_GRAPHICS   |                         | If set, override the specified zwift graphics profile                                                                                 |
+| ZWIFT_OVERRIDE_RESOLUTION |                         | If set, change game resolution (2560x1440, 3840x2160, ...)                                                                            |
+| ZWIFT_FG                  |                         | If set, run the process in fg instead of bg (-d)                                                                                      |
+| ZWIFT_NO_GAMEMODE         |                         | If set, don't run gamemode                                                                                                            |
+| WINE_EXPERIMENTAL_WAYLAND |                         | If set, try to use experimental wayland support in wine 9                                                                             |
+| NETWORKING                | bridge                  | Sets the type of container networking to use.                                                                                         |
+| ZWIFT_UID                 | current users id        | Sets the UID that Zwift will run as (docker only)                                                                                     |
+| ZWIFT_GID                 | current users group id  | Sets the GID that Zwift will run as (docker only)                                                                                     |
+| DEBUG                     |                         | If set enabled debug of zwift script "set -x"                                                                                         |
+| VGA_DEVICE_FLAG           |                         | Override GPU/device flags for container (--gpus=all)                                                                                  |
+| PRIVILEGED_CONTAINER      | 0                       | If set, container will run in priviledged mode, SELinux label separation will be disabled (--privileged --security-opt label=disable) |
 
 These environment variables can be used to alter the execution of the zwift bash script.
 

--- a/bin/build-image.sh
+++ b/bin/build-image.sh
@@ -28,14 +28,15 @@ fi
 
 GENERAL_FLAGS=(
     -it
-    --privileged
     --network bridge
     --name zwift
-    --security-opt label=disable
+    --security-opt label=type:container_runtime_t
+    --device /dev/dri
     --hostname $HOSTNAME
 
     -e DISPLAY=$DISPLAY
     -e XAUTHORITY=$XAUTHORITY
+    -e CONTAINER=$CONTAINER_TOOL
 
     -v /tmp/.X11-unix:/tmp/.X11-unix
     -v /run/user/$UID:/run/user/$ZWIFT_UID
@@ -55,7 +56,6 @@ if [[ "$CONTAINER_TOOL" == "podman" ]]; then
     # Add ipc host to deal with an SHM issue on some machines.
     PODMAN_FLAGS=(
         --userns keep-id:uid=$ZWIFT_UID,gid=$ZWIFT_GID
-        --ipc host 
     )
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,13 +5,15 @@ set -x
 # Check whetehr we are running in Docker/ Podman
 # Docker has the file /.dockerenv 
 # Podman exposes itself in /run/.containerenv
-if [[ -f "/.dockerenv" ]]; then
-    CONTAINER="docker"
-elif [[ ! -z $(cat /run/.containerenv | grep "podman") ]]; then
-    CONTAINER="podman"
-else
-    echo "Unknown Container."
-    exit 1
+if ! ( [[ "$CONTAINER" == "docker" ]] || [[ "$CONTAINER" == "podman" ]] ); then
+    if [[ -f "/.dockerenv" ]]; then
+        CONTAINER="docker"
+    elif [[ ! -z $(cat /run/.containerenv | grep "podman") ]]; then
+        CONTAINER="podman"
+    else
+        echo "Unknown Container."
+        exit 1
+    fi
 fi
 
 # If Wayland Experimental need to blank DISPLAY here to enable Wayland.

--- a/zwift.sh
+++ b/zwift.sh
@@ -209,16 +209,15 @@ fi
 # Define Base Container Parameters
 GENERAL_FLAGS=(
     --rm
-    --privileged
     --network $NETWORKING
     --name zwift-$USER
-    --security-opt label=disable
     --hostname $HOSTNAME
 
     -e DISPLAY=$DISPLAY
     -e ZWIFT_UID=$CONTAINER_UID
     -e ZWIFT_GID=$CONTAINER_GID
     -e PULSE_SERVER=/run/user/$CONTAINER_UID/pulse/native
+    -e CONTAINER=$CONTAINER_TOOL
 
     -v zwift-$USER:/home/user/.wine/drive_c/users/user/Documents/Zwift
     -v /run/user/$LOCAL_UID/pulse:/run/user/$CONTAINER_UID/pulse
@@ -226,6 +225,14 @@ GENERAL_FLAGS=(
 
 ###################################
 ##### SPECIFIC CONFIGURATIONS #####
+
+# Setup container security flags
+if [[ $PRIVILEGED_CONTAINER -eq "1" ]]
+then
+    CONT_SEC_FLAG=(--privileged --security-opt label=disable) # privileged container, less secure
+else
+    CONT_SEC_FLAG=(--security-opt label=type:container_runtime_t) # more secure
+fi
 
 # Check for proprietary nvidia driver and set correct device to use (respects existing VGA_DEVICE_FLAG)
 if [[ -z "$VGA_DEVICE_FLAG" ]]; then
@@ -339,6 +346,7 @@ POSITIONAL_ARGS=("$@")
 CMD=(
     "$CONTAINER_TOOL" run
     "${GENERAL_FLAGS[@]}"
+    "${CONT_SEC_FLAG[@]}"
     "${ZWIFT_FG_FLAG[@]}"
     "${ZWIFT_CONFIG_FLAG_ARR[@]}"
     "${ZWIFT_PASSWORD_SECRET_ARR[@]}"


### PR DESCRIPTION
Removed the usage of `--privileged` and `--security-opt label=disable` by default to improve security of the container. `--security-opt label=type:container_runtime_t` is used instead. 

Fallback to insecure container with `--privileged` and `--security-opt label=disable` if the environment variable `PRIVILEGED_CONTAINER` is set to `1` for `zwift.sh`.

`--ipc host` flag is also removed from Podman build command, as it is also insecure.

Tested on Fedora 42 (amd64, SELinux Enforcing) with Podman 5.6.1. Builds and runs fine with the more secure options. 

More testing (with Docker and AppArmor systems) is likely needed before merge.

Fixes #221