### PR TITLE
Fix zwift.sh warning on line 72

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If dbus is available through a unix socket, the screensaver will be inhibited ev
 | ZWIFT_WORKOUT_DIR         |                         | Set the workouts directory location                                                                                                   |
 | ZWIFT_ACTIVITY_DIR        |                         | Set the activities directory location                                                                                                 |
 | ZWIFT_LOG_DIR             |                         | Set the logs directory location                                                                                                       |
-| ZWIFT_OVERRIDE_GRAPHICS   |                         | If set, override the specified zwift graphics profile                                                                                 |
+| ZWIFT_OVERRIDE_GRAPHICS   |                         | If set, override the default zwift graphics profiles                                                                                  |
 | ZWIFT_OVERRIDE_RESOLUTION |                         | If set, change game resolution (2560x1440, 3840x2160, ...)                                                                            |
 | ZWIFT_FG                  |                         | If set, run the process in fg instead of bg (-d)                                                                                      |
 | ZWIFT_NO_GAMEMODE         |                         | If set, don't run gamemode                                                                                                            |

--- a/zwift.sh
+++ b/zwift.sh
@@ -69,7 +69,7 @@ if [[ ! -z $ZWIFT_LOG_DIR ]]; then
 fi
 
 # If overriding a zwift graphics profile, map to the corresponding file.
-if [ "$ZWIFT_OVERRIDE_GRAPHICS" -eq "1" ]; then
+if [[ $ZWIFT_OVERRIDE_GRAPHICS -eq "1" ]]; then
     ZWIFT_GRAPHICS_CONFIG="$HOME/.config/zwift/graphics.txt"
 
     # Check for $USER specific graphics config file.

--- a/zwift.sh
+++ b/zwift.sh
@@ -68,7 +68,7 @@ if [[ ! -z $ZWIFT_LOG_DIR ]]; then
     ZWIFT_LOG_VOL="-v $ZWIFT_LOG_DIR:/home/user/.wine/drive_c/users/user/Documents/Zwift/Logs"
 fi
 
-# If overriding a zwift graphics profile, map to the corresponding file.
+# If overriding zwift graphics then map custom config to the graphics profiles.
 if [[ $ZWIFT_OVERRIDE_GRAPHICS -eq "1" ]]; then
     ZWIFT_GRAPHICS_CONFIG="$HOME/.config/zwift/graphics.txt"
 


### PR DESCRIPTION
The minor fixes from #222. But given that it will probably be a bit before that one gets merged, it's probably best to already merge these minor fixes first.

```console
./zwift.sh: line 72: [: : integer expression expected
```