### PR TITLE
Add missing semicolon to nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -107,7 +107,7 @@
               zwiftWorkoutDir = mkOption { type = str; default = ""; };
               zwiftActivityDir = mkOption { type = str; default = ""; };
               zwiftLogDir = mkOption { type = str; default = ""; };
-              zwiftScreenshotsDir = mkOption { type = str; default = "" };
+              zwiftScreenshotsDir = mkOption { type = str; default = ""; };
               zwiftOverrideGraphics = mkOption { type = bool; default = false; };
               zwiftOverrideResolution = mkOption { type = str; default = ""; };
               zwiftFg = mkOption { type = bool; default = false; };


### PR DESCRIPTION
https://github.com/netbrain/zwift/pull/228#issuecomment-3401699392

> @glennvl @netbrain
> 
> ```
>        error: syntax error, unexpected '}', expecting ';'
>        at «github:netbrain/zwift/4005fa9614e08ce7895a5c69b81bf8eb001aa6c7»/flake.nix:110:73:
>           109|               zwiftLogDir = mkOption { type = str; default = ""; };
>           110|               zwiftScreenshotsDir = mkOption { type = str; default = "" };
>              |                                                                         ^
>           111|               zwiftOverrideGraphics = mkOption { type = bool; default = false; };
> ```

Fix missing semicolon. I don't use nix myself, so I don't have an easy way to validate the nix flake against easily avoidable syntax errors like this. @wakira Are you perhaps aware of a nix flake linter we could use in a github action to avoid mistakes like this?