### PR TITLE
Lint nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
           zwiftPassword,
           zwiftWorkoutDir,
           zwiftActivityDir,
-          zwiftLogDir
+          zwiftLogDir,
           zwiftScreenshotsDir,
           zwiftOverrideGraphics,
           zwiftOverrideResolution,
@@ -43,7 +43,7 @@
           IMAGE=${image}
           VERSION=${tag}
           DONT_CHECK=${dontCheck}
-          DONT_PULL=${dontPull
+          DONT_PULL=${dontPull}
           DRYRUN=${dryRun}
           INTERACTIVE=${interactive}
           CONTAINER_TOOL=${containerTool}
@@ -114,7 +114,7 @@
               zwiftNoGameMode = mkOption { type = bool; default = false; };
               wineExperimentalWayland = mkOption { type = bool; default = false; };
               networking = mkOption { type = str; default = ""; };
-              zwiftUid = mkOption { type = str; default = "" };
+              zwiftUid = mkOption { type = str; default = ""; };
               zwiftGid = mkOption { type = str; default = ""; };
               vgaDeviceFlag = mkOption { type = str; default = ""; };
               debug = mkOption { type = bool; default = false; };


### PR DESCRIPTION
Add a github action to lint the nix flake, to avoid easily preventable issues such as syntax errors. Use the `oxalica/nil` language server to validate the nix flake as suggested by @wakira in #229.

* With errors in the nix flake: <https://github.com/glennvl/zwift-linux/actions/runs/18559524742/job/52904875597>
* After fixing the errors again: <https://github.com/glennvl/zwift-linux/actions/runs/18559669425/job/52905325315>