### PR TITLE
Fix shebang for NixOs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -73,6 +73,7 @@
 
         installPhase = ''
           runHook preInstall
+          patchShebangs .
           install -Dm755 ${nixosRun} -T $out/bin/${pname}
           install -Dm644 $src/share/icons/hicolor/scalable/apps/zwift.svg \
               -T $out/share/icons/hicolor/scalable/apps/zwift.svg

--- a/zwift.sh
+++ b/zwift.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 if [ -n "${DEBUG}" ]; then set -x; fi
 
 # Message Box to simplify errors/ and questions.


### PR DESCRIPTION
I made two possible fix (see the two commits):
- revert the change from #232 
- patch the shebang in the flake

Both work for me but the second one has the disadvantage that the script will always report as being out of date.
This could be workaround by ignoring the first line of the script in the sha256sum though.
Let me know what you prefer.

There are other scripts with the `#!/bin/bash` shebang but from what I understand they are run either by the CI or from within a container, so should be fine.