### PR TITLE
Use same shebang in all scripts

### DIFF
--- a/bin/build-image.sh
+++ b/bin/build-image.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
 SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ $EUID -eq 0 ]]; then
   ROOT_BIN=/usr/local/bin

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -x
 

--- a/run_zwift.sh
+++ b/run_zwift.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -x
 

--- a/update_zwift.sh
+++ b/update_zwift.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -x
 

--- a/zwift-auth.sh
+++ b/zwift-auth.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 set -e
 
 LAUNCHER_CLIENT_ID="Game_Launcher"


### PR DESCRIPTION
Switch the shebang in all scripts from

```bash
#!/bin/bash
```

to

```bash
#!/usr/bin/env bash
```

for consistency and portability.

This shebang was already used in the `zwift.sh` script since it is required for nix.