### PR TITLE
Update ZWIFT_PASSWORD workflow to also support docker

### DIFF
--- a/zwift.sh
+++ b/zwift.sh
@@ -152,9 +152,13 @@ if [ -n "$ZWIFT_USERNAME" ]; then
     elif [[ $HAS_PLAINTEXT_PASSWORD -eq "1" ]]; then
         ZWIFT_PASSWORD_SECRET="-e ZWIFT_PASSWORD=$ZWIFT_PASSWORD"
     else
-        echo "No password found for $ZWIFT_USERNAME..."
-        echo "To avoid manually entering your zwift password every time, either start zwift with \`ZWIFT_PASSWORD=\"hunter2\" zwift\` or store it in the secret-store"
-        echo "\`secret-tool store --label \"Zwift password for $ZWIFT_USERNAME\" application zwift username $ZWIFT_USERNAME\`"
+        msgbox info \
+"No password found for **$ZWIFT_USERNAME**.
+To avoid manually entering your Zwift password each time, you can either:
+1. Start Zwift using the command:
+   ZWIFT_PASSWORD=\"hunter2\" zwift
+2. Store your password securely in the secret store with the following command:
+   secret-tool store --label \"Zwift password for $ZWIFT_USERNAME\" application zwift username $ZWIFT_USERNAME" 1
     fi
 else
     echo "No Zwift credentials found..."


### PR DESCRIPTION
As noted in discussion https://github.com/netbrain/zwift/discussions/256, automatically logging into zwift does not work with docker as its secret tool only works in swarm mode. This PR updates the workflow for ZWIFT_PASSWORD such that it works with both docker (use an environment variable) and with podman (use a secret).

```mermaid
flowchart LR
    A[[Start]] -->  C{ZWIFT_PASSWORD set?}
    C -->|No| D{container tool is podman and container tool secret exists?}
    D -->|Yes| E[SECRET_FOUND=True]
    D -->|No| F[Try to get ZWIFT_PASSWORD from linux secret-tool]
    E --> G( )
    F --> G
    C -->|Yes| G
    G --> L{ZWIFT_PASSWORD set?}
    L -->|Yes| H[PASSWORD_SET=True]
    H --> I[If podman, try to create/update container tool secret]
    I --> J{Secret created/updated successfully?}
    J -->|Yes| K[SECRET_FOUND=True]
    J -->|No| M[[End]]
   L -->|No| M
   K --> M
```

```mermaid
flowchart LR
    A[[Start]] -->  B{SECRET_FOUND ?}
    B -->|Yes| C[Use --secret for password]
    B -->|No| D{PASSWORD_SET?}
    D -->|Yes| E[Use -e for password]
    D --> |No| F[[End]]
    E --> F
    C --> F
```