### PR TITLE
Generate temporary env file

### DIFF
--- a/zwift.sh
+++ b/zwift.sh
@@ -451,7 +451,9 @@ if [[ -n "$DRYRUN" ]]; then
     msgbox ok "DRYRUN:"
     msgbox ok "environment variables ($ENV_FILE):"
     for env_var in "${ENVIRONMENT_VARIABLES[@]}"; do
-        msgbox ok "  ${env_var//ZWIFT_PASSWORD=*/ZWIFT_PASSWORD=REDACTED}"
+        env_var=${env_var//\\/\\\\}                                  # escape backslashes
+        env_var=${env_var//ZWIFT_PASSWORD=*/ZWIFT_PASSWORD=REDACTED} # redact password
+        msgbox ok "  $env_var"
     done
     msgbox ok "$CONTAINER_TOOL command:"
     msgbox ok "  $(printf '%q ' "${CMD[@]}")"


### PR DESCRIPTION
## Summary

Use an env file instead of passing environment variables on the command line. This is a workaround for environment variables that have special characters such as backslashes, spaces, ... in their value. Especially revelant for passwords since those tend to include special characters. The advantage of using an env file is that environment variables can be written as `KEY=VALUE` without requiring any escape characters, quotes, ...

## Implementation

* Create an array variable in which environment variables can be appended.
* Create a temporary file that will be used as env file.
* Add environment variables to the array instead of adding `-e VARIABLE=VALUE`.
* Before starting the container, dump the array of environment variables to the temporary env file.
* When the script exits, automatically remove the env file (using an exit trap). When the container has started the file is no longer needed and can be safely removed (no need to wait for the container to exit).

The temporary file is created using `ENV_FILE=$(mktemp -q /tmp/zwift-container.env.XXXXXXXXXX)`. Which results in a file with permissions `600` (rw for the owner, no access for everyone else) and owner and group being the user that invoked the script. This should be as safe as we can get to temporarily store the zwift password in plain text format (only relevant when using docker, when using podman the secret store is used instead of plain text password).

## Debugging

Since we now use an env file for environment variables instead of passing them with `-e` on the commandline, the environment variables are not present anymore when looking at the commandline with for example `DRYRUN=1`.

* When using `DRYRUN=1`, the list of environment variables will also be printed in addition to the commandline. So all the information is still there. Note that if a password is present in the list of environment variables, it will be printed as `ZWIFT_PASSWORD=REDACTED` instead of showing the actual password.
* Security consideration: When using `DRYRUN=1`, the environment variables are only printed to the screen and never actually written to the env file. Since the container never actually starts, it's not necessary to actually create the file, so we can avoid exposing the password in plain text.
* Alternatively, `INTERACTIVE=1` can be used to launch the container in interactive mode. In the container the environment variables can be inspected with the `env` command. This will print a list of all environment variables (including the plain text password, for docker and podman).

## Sourcing config files and passing them as env files

The config files used to be both sourced into the zwift script and passed as env files to the container. This PR no longer passes the config files as env files to the container. Because files that are supposed to be sourced and env files have different syntax requirements.

* Files that are sourced
  * Are treated as bash scripts, they can contain both code and variable assignments
  * The variable assignments need to be properly escaped or single-quoted
* Environment files
  * Can only contain `key=value` entries and lines starting with a `#` are treated as comments
  * Values must not be quoted or escaped, all characters are literal
* Examples that show difference in behaviour
  * `KEY=my value`
     * source: `KEY` is an array of two values `my` and `value`
     * env file: `KEY` has the value `my value`
  * `KEY=my value \`
    * source: syntax error trying to parse file
    * env file: `KEY` has  the value `my value \`  
  * `KEY='my value \'`  
    * source: `KEY` has the value `my value \`
    * env file: `KEY` has the value `'my value \'`
  * `KEY = value # something`
    * source: `KEY` has the value `value` (`somthing` is treated as a comment)
    * env file: `KEY` has the value `value # something`

Both sourcing and using the files as env files could easily result in errors and different values for environment variables in the zwift script and the container.

## Discussion

Since the config files are no longer passed as env files to the container, the user can no longer inject their own environment variables in the container.

* Is it necessary for the user to be able to do so?
* If yes, we can easily implement a new feature to allow the user to supply their own env file with environment variables to be passed to the container.

   ```bash
   ADDITIONAL_ENV_FILES=()   

   load_env_file() {
       EXTRA_ENV_FILE="$1"
       msgbox info "Looking for env file $EXTRA_ENV_FILE"
       if [[ -f "$EXTRA_ENV_FILE" ]]; then
           msgbox ok "Using $ENV_FILE"
           ADDITIONAL_ENV_FILES+=(--env-file "$EXTRA_ENV_FILE")
       fi
   }

   load_env_file "$HOME/.config/zwift/container.env"
   load_env_file "$HOME/.config/zwift/$USER-container.env"

   # Add "${ADDITIONAL_ENV_FILES[@]}" to CMD.
   ```

## Related issues

* #261
* #259 
* #190 