### PR TITLE
Only run deployment workflows in netbrain/zwift repository

### DIFF
--- a/.github/workflows/sponsors.yaml
+++ b/.github/workflows/sponsors.yaml
@@ -7,6 +7,7 @@ permissions:
   contents: write
 jobs:
   deploy:
+    if: github.repository == 'netbrain/zwift'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️

--- a/.github/workflows/zwift_build_from_scratch.yaml
+++ b/.github/workflows/zwift_build_from_scratch.yaml
@@ -2,9 +2,10 @@ name: Zwift build from scratch
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 1 */3 *"    
+    - cron: "0 0 1 */3 *"
 jobs:
   zwift_build:
+    if: github.repository == 'netbrain/zwift'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     concurrency: zwift

--- a/.github/workflows/zwift_build_matrix.yaml
+++ b/.github/workflows/zwift_build_matrix.yaml
@@ -3,6 +3,7 @@ on:
   workflow_dispatch:
 jobs:
   zwift_build:
+    if: github.repository == 'netbrain/zwift'
     runs-on: ubuntu-22.04
     timeout-minutes: 360
     strategy:

--- a/.github/workflows/zwift_push.yaml
+++ b/.github/workflows/zwift_push.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   zwift_push:
+    if: github.repository == 'netbrain/zwift'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     concurrency: zwift

--- a/.github/workflows/zwift_updater.yaml
+++ b/.github/workflows/zwift_updater.yaml
@@ -5,6 +5,7 @@ on:
     - cron: "0 * * * *"
 jobs:
   zwift_updater:
+    if: github.repository == 'netbrain/zwift'
     runs-on: ubuntu-22.04
     timeout-minutes: 360
     concurrency: zwift
@@ -55,4 +56,3 @@ jobs:
           docker tag netbrain/zwift:$VERSION netbrain/zwift:latest
           docker push netbrain/zwift:$VERSION
           docker push netbrain/zwift:latest
-


### PR DESCRIPTION
By default, when a repository is forked, github actions for that repository are disabled in the fork. But sometimes it can be handy to enable actions in the fork to be able to run linters etc.

The linting actions for this repository are configured to be triggered by pushes of certain file types. So they don't strictly need a pull request and can therefore also be run in forked repositories if desired by the contributor. This can help contributors to see linting warnings before opening a pull request.

Indeed these workflows do their job when actions are enabled in the forked repository. But there's also the actions related to deploying new versions of zwift etc. These workflows also run when actions are enabled in the forked repository, which is not desirable. In our case, they fail (because they obviously can't access the netbrain docker account) and cause a lot of spam (since some are triggered by a cron job and fail each time).

This PR prevents deployment workflows from running in forked repositories (if actions are enabled for the fork), by adding a simple check to the jobs in those workflows:

```yaml
if: github.repository == 'netbrain/zwift'
```

**Source**: <https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-only-run-job-for-specific-repository>

**Note**: For obvious reasons I can't test this in my fork, so we'll have to see if I did not break anything by adding it.