### PR TITLE
Give github jobs meaningful names

### DIFF
--- a/.github/workflows/lint_bash_scripts.yaml
+++ b/.github/workflows/lint_bash_scripts.yaml
@@ -7,6 +7,7 @@ on: # yamllint disable-line rule:truthy
       - "master"
 jobs:
   validate-shell-scripts:
+    name: Lint with shellcheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository code
@@ -16,6 +17,7 @@ jobs:
       - name: Check bash scripts for errors and warnings
         run: find . -path ./.git -prune -o -name "*.sh" -exec shellcheck {} +
   check-shell-scripts-formatted:
+    name: Check formatting with shfmt
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository code

--- a/.github/workflows/lint_dockerfile.yaml
+++ b/.github/workflows/lint_dockerfile.yaml
@@ -7,6 +7,7 @@ on: # yamllint disable-line rule:truthy
       - "master"
 jobs:
   validate-dockerfile:
+    name: Check Dockerfile with docker buildx
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository code
@@ -19,6 +20,7 @@ jobs:
           call: check
           file: src/Dockerfile
   lint-dockerfile:
+    name: Lint Dockerfile with hadolint
     runs-on: ubuntu-latest
     needs: validate-dockerfile
     steps:
@@ -30,6 +32,7 @@ jobs:
           config: .hadolint.yaml
           dockerfile: src/Dockerfile
   validate-squash-dockerfile:
+    name: Check squash.Dockerfile with docker buildx
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository code
@@ -42,6 +45,7 @@ jobs:
           call: check
           file: src/squash.Dockerfile
   lint-squash-dockerfile:
+    name: Lint squash.Dockerfile with hadolint
     runs-on: ubuntu-latest
     needs: validate-squash-dockerfile
     steps:

--- a/.github/workflows/lint_github_actions.yaml
+++ b/.github/workflows/lint_github_actions.yaml
@@ -7,6 +7,7 @@ on: # yamllint disable-line rule:truthy
       - "master"
 jobs:
   validate-github-actions:
+    name: Lint with actionlint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository code

--- a/.github/workflows/lint_markdown.yaml
+++ b/.github/workflows/lint_markdown.yaml
@@ -7,6 +7,7 @@ on: # yamllint disable-line rule:truthy
       - "master"
 jobs:
   validate-markdown:
+    name: Lint with markdownlint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository code
@@ -17,6 +18,7 @@ jobs:
           config: ".markdownlint-cli2.yaml"
           globs: ""
   spellcheck-markdown:
+    name: Spellcheck with cspell
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository code

--- a/.github/workflows/lint_nix_flake.yaml
+++ b/.github/workflows/lint_nix_flake.yaml
@@ -7,6 +7,7 @@ on: # yamllint disable-line rule:truthy
       - "master"
 jobs:
   validate-nix-flake:
+    name: Lint with nil
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository code
@@ -18,6 +19,7 @@ jobs:
       - name: Check nix flake for errors
         run: nil diagnostics -- *.nix
   check-nix-flake-formatted:
+    name: Check formatting with nixfmt
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository code
@@ -29,6 +31,7 @@ jobs:
       - name: Check if nix flake is formatted
         run: nixfmt --check -- *.nix
   build-nix-flake:
+    name: Build flake
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository code

--- a/.github/workflows/lint_yaml.yaml
+++ b/.github/workflows/lint_yaml.yaml
@@ -7,6 +7,7 @@ on: # yamllint disable-line rule:truthy
       - "master"
 jobs:
   validate-yaml:
+    name: Lint with yamllint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository code


### PR DESCRIPTION
## Summary

The name of github jobs is visible in the list of action runs in pull requests. Currently jobs do not have a name assigned, so it shows the id of the job as name.

In this PR jobs are given a meaningful name that includes the tool that is used in the job. That way, if a run fails, it is immediately apparent in the PR which tool failed. This makes it obvious on first sight which tool failed instead of having to click through to the failed job.

## Before (job ids)

<img width="807" height="382" alt="image" src="https://github.com/user-attachments/assets/2d64a561-aa3f-4afa-8849-cab6938ec4d4" />

## After (meaningful name/description)

<img width="807" height="382" alt="image" src="https://github.com/user-attachments/assets/47d953c4-e8a6-428a-912f-04875ed00331" />