### PR TITLE
Fix DISPLAY not exported in build workflows

### DIFF
--- a/.github/workflows/zwift_build_from_scratch.yaml
+++ b/.github/workflows/zwift_build_from_scratch.yaml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/checkout@v6
     - name: Build zwift
       run: |
-        readonly DISPLAY=":99"
+        export DISPLAY=":99"
 
         version="$(curl -s http://cdn.zwift.com/gameassets/Zwift_Updates_Root/Zwift_ver_cur.xml \
             | grep -oP 'sversion="\K.*?(?=")' | cut -f 1 -d ' ')"

--- a/.github/workflows/zwift_build_matrix.yaml
+++ b/.github/workflows/zwift_build_matrix.yaml
@@ -42,7 +42,7 @@ jobs:
       uses: actions/checkout@v6
     - name: Build zwift
       run: |
-        readonly DISPLAY=":99"
+        export DISPLAY=":99"
 
         echo "Starting build..."
 


### PR DESCRIPTION
## Summary
- `readonly` does not export variables to the environment, causing `xhost` and `docker run` to not see `DISPLAY`
- The updater workflow was already fixed directly on master (b297551), this PR fixes the same issue in:
  - `zwift_build_matrix.yaml`
  - `zwift_build_from_scratch.yaml`
- Changes `readonly DISPLAY=":99"` to `export DISPLAY=":99"`

## Context
Introduced in 75019e6 ("Strict lint bash in workflows") which mechanically replaced `export` with `readonly`.