### PR TITLE
No longer use old Documents/Zwift location

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -29,7 +29,6 @@ readonly CONTAINER_TOOL="${CONTAINER_TOOL:?}"
 readonly WINE_USER_HOME="/home/user/.wine/drive_c/users/user"
 readonly ZWIFT_HOME="/home/user/.wine/drive_c/Program Files (x86)/Zwift"
 readonly ZWIFT_DOCS="${WINE_USER_HOME}/AppData/Local/Zwift"
-readonly ZWIFT_DOCS_OLD="${WINE_USER_HOME}/Documents/Zwift" # TODO remove when no longer needed (301)
 
 msgbox() {
     local type="${1:?}" # Type: info, ok, warning, error
@@ -130,7 +129,6 @@ if [[ ${CONTAINER_TOOL} == "docker" ]]; then
             chown -R user:user /home/user || return 1
         else
             chown -R user:user "${ZWIFT_DOCS}" || return 1
-            chown -R user:user "${ZWIFT_DOCS_OLD}" || return 1 # TODO remove when no longer needed (301)
         fi
     }
 

--- a/src/update_zwift.sh
+++ b/src/update_zwift.sh
@@ -26,7 +26,6 @@ readonly CONTAINER_TOOL="${CONTAINER_TOOL:?}"
 readonly WINE_USER_HOME="/home/user/.wine/drive_c/users/user"
 readonly ZWIFT_HOME="/home/user/.wine/drive_c/Program Files (x86)/Zwift"
 readonly ZWIFT_DOCS="${WINE_USER_HOME}/AppData/Local/Zwift"
-readonly ZWIFT_DOCS_OLD="${WINE_USER_HOME}/Documents/Zwift" # TODO remove when no longer needed (301)
 
 msgbox() {
     local type="${1:?}" # Type: info, ok, warning, error
@@ -157,7 +156,6 @@ cleanup() {
     rm -rf -- "/home/user/.cache/wine*" || true
     # remove Zwift documents because it causes permission errors with podman
     rm -rf -- "${ZWIFT_DOCS}" || true
-    rm -rf -- "${ZWIFT_DOCS_OLD}" || true # TODO remove when no longer needed  (301)
 }
 
 trap cleanup EXIT

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -8,7 +8,6 @@ readonly USER_CONFIG_DIR="${HOME}/.config/zwift"
 readonly WINE_USER_HOME="/home/user/.wine/drive_c/users/user"
 readonly ZWIFT_HOME="/home/user/.wine/drive_c/Program Files (x86)/Zwift"
 readonly ZWIFT_DOCS="${WINE_USER_HOME}/AppData/Local/Zwift"
-readonly ZWIFT_DOCS_OLD="${WINE_USER_HOME}/Documents/Zwift" # TODO remove when no longer needed (301)
 
 if [[ -t 1 ]]; then
     readonly COLORED_OUTPUT_SUPPORTED="1"
@@ -319,7 +318,6 @@ container_args+=(
     --hostname "${HOSTNAME}"
     --env-file "${container_env_file}"
     -v "zwift-${USER}:${ZWIFT_DOCS}"
-    -v "zwift-${USER}:${ZWIFT_DOCS_OLD}" # TODO remove when no longer needed (301)
     -v "/run/user/${local_uid}/pulse:/run/user/${container_uid}/pulse"
 )
 


### PR DESCRIPTION
I got notified by Zwift that the migration from Documents/Zwift to AppData/Zwift has been completed. For context, see #301 and #302.

This PR removes the transition where we use both Documents/Zwift and AppData/Zwift.

> :warning: **Important**
>
> - This requires the latest version of the Zwift launcher. So we need to force a reinstall of Zwift. The easiest is probably to manually trigger the build from scratch action after merging this PR.
> - Alternatively, we could wait until after v1.109.0 has been released in a few days to merge this. That will trigger the new launcher to be used. The current way of mounting to both locations will still work with the new launcher.