### PR TITLE
Update github actions to latest version

### DIFF
--- a/.github/workflows/lint_everything.yaml
+++ b/.github/workflows/lint_everything.yaml
@@ -38,9 +38,9 @@ jobs:
     - name: Checkout repository code
       uses: actions/checkout@v6
     - name: Install docker buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
     - name: Check Dockerfile for errors
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         call: check
         file: src/Dockerfile
@@ -62,7 +62,7 @@ jobs:
     - name: Checkout repository code
       uses: actions/checkout@v6
     - name: Check github actions for errors
-      uses: devops-actions/actionlint@467e2ce19b2310e93c9ffa0b50fe31f86b5a7f23
+      uses: devops-actions/actionlint@e7ee33fbf5aa8c9f9ee1145137f3e52e25d6a35b
   markdown-lint:
     name: Markdown - Lint with markdownlint
     runs-on: ubuntu-latest
@@ -70,7 +70,7 @@ jobs:
     - name: Checkout repository code
       uses: actions/checkout@v6
     - name: Check markdown files for errors
-      uses: DavidAnson/markdownlint-cli2-action@v20
+      uses: DavidAnson/markdownlint-cli2-action@v22
       with:
         config: .markdownlint-cli2.yaml
         globs: ''
@@ -81,7 +81,7 @@ jobs:
     - name: Checkout repository code
       uses: actions/checkout@v6
     - name: Spellcheck markdown files
-      uses: streetsidesoftware/cspell-action@v7
+      uses: streetsidesoftware/cspell-action@v8
       with:
         config: .cspell.yaml
         suggestions: true

--- a/.github/workflows/zwift_build_from_scratch.yaml
+++ b/.github/workflows/zwift_build_from_scratch.yaml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 60
     steps:
     - name: Login to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/zwift_push.yaml
+++ b/.github/workflows/zwift_push.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: netbrain/free-disk-space-action@v0.0.1
     - name: Login to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/zwift_updater.yaml
+++ b/.github/workflows/zwift_updater.yaml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 360
     steps:
     - name: Login to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This PR updates github actions used in our workflows to the latest version.

**Reason**: Warning when running github actions

> :warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: .... Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Not all actions updated

The following actions still receive updates, but have not updated node yet:

- [DavidAnson/markdownlint-cli2-action](https://github.com/DavidAnson/markdownlint-cli2-action)

The following actions still use node 20 and have no update available:

- [actions/configure-pages](https://github.com/actions/configure-pages)
- [actions/deploy-pages](https://github.com/actions/deploy-pages)

Both have PRs to update the node version since the summer of 2025, but do not seem to be actively maintained by the owner (last update two years ago).

Hopefully they'll receive an update soon or we may have to look for an alternative at some point.