### PR TITLE
Refactor uid gid

### DIFF
--- a/docs/advanced/nixos.md
+++ b/docs/advanced/nixos.md
@@ -72,10 +72,6 @@ environment variables in camelCase:
     wineExperimentalWayland = false;
     # Networking mode for the container ("bridge" is default)
     networking = "bridge";
-    # User ID for running the container (usually your own UID)
-    zwiftUid = "1000";
-    # Group ID for running the container (usually your own GID)
-    zwiftGid = "1000";
     # GPU/device flags override (Docker: "--gpus=all", Podman/CDI: "--device=nvidia.com/gpu=all")
     vgaDeviceFlag = "--device=nvidia.com/gpu=all";
     # Enable debug output and verbose logging if true

--- a/docs/advanced/podman-support.md
+++ b/docs/advanced/podman-support.md
@@ -15,7 +15,3 @@ From Podman 4.3 this became automatic by providing the Container UID/GID and pod
 For example if the host uid/gid is 1001/1001 then we need to map the host resources from `/run/user/1001` to the container
 resource `/run/user/1000` and map the user and group id's the same. This had to be done manually on the host podman start using
 `--uidmap` and `--gidmap` (not covered here).
-
-{: .warning }
-Using ZWIFT_UID/GID will only work if the user starting podman has access to the `/run/user/$ZWIFT_UID` resources and does
-not work the same way as in Docker so is not supported.

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -79,8 +79,6 @@ These environment variables can be used to alter the execution of the zwift bash
 | [`ZWIFT_NO_GAMEMODE`](#zwift_no_gamemode)                 | `0`                        | If set to `1`, don't run game mode                  |
 | [`WINE_EXPERIMENTAL_WAYLAND`](#wine_experimental_wayland) | `0`                        | If set to `1`, use native Wayland                   |
 | [`NETWORKING`](#networking)                               | `bridge`                   | Sets the type of container networking to use        |
-| [`ZWIFT_UID`](#zwift_uid)                                 | `$(id -u)`                 | Sets the UID that Zwift will run as                 |
-| [`ZWIFT_GID`](#zwift_gid)                                 | `$(id -g)`                 | Sets the GID that Zwift will run as                 |
 | [`VGA_DEVICE_FLAG`](#vga_device_flag)                     |                            | Override container GPU/device flags                 |
 | [`PRIVILEGED_CONTAINER`](#privileged_container)           | `0`                        | If set to `1`, run the container in privileged mode |
 
@@ -655,52 +653,6 @@ Configure how the container connects to the Internet.
 | Default value     | `bridge`                             |
 | Commandline usage | `NETWORKING="host" zwift`            |
 | Config file usage | `NETWORKING="host"`                  |
-
----
-
-### `ZWIFT_UID`
-
-See also [`ZWIFT_GID`](#zwift_gid).
-
-Use this option to launch Zwift from a different user id.
-
-| Item              | Description              |
-|:------------------|:-------------------------|
-| Allowed values    | number                   |
-| Default value     | `$(id -u)`               |
-| Commandline usage | `ZWIFT_UID="1001" zwift` |
-| Config file usage | `ZWIFT_UID="1001"`       |
-
-{: .warning }
-> It is strongly discouraged to use a `ZWIFT_UID` that is different from your user uid. If you decide to do so anyway, know
-> that:
->
-> - It does not work with podman
-> - It does not work with Wayland
-> - Cats and dogs may start living together
-
----
-
-### `ZWIFT_GID`
-
-See also [`ZWIFT_UID`](#zwift_uid).
-
-Use this option to launch Zwift from a different group id.
-
-| Item              | Description              |
-|:------------------|:-------------------------|
-| Allowed values    | number                   |
-| Default value     | `$(id -g)`               |
-| Commandline usage | `ZWIFT_GID="1001" zwift` |
-| Config file usage | `ZWIFT_GID="1001"`       |
-
-{: .warning }
-> It is strongly discouraged to use a `ZWIFT_GID` that is different from your user gid. If you decide to do so anyway, know
-> that:
->
-> - It does not work with podman
-> - It does not work with Wayland
-> - Cats and dogs may start living together
 
 ---
 

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -80,8 +80,6 @@ These environment variables can be used to alter the execution of the zwift bash
 | [`ZWIFT_NO_GAMEMODE`](#zwift_no_gamemode)                 | `0`                        | If set to `1`, don't run game mode                  |
 | [`WINE_EXPERIMENTAL_WAYLAND`](#wine_experimental_wayland) | `0`                        | If set to `1`, use native Wayland                   |
 | [`NETWORKING`](#networking)                               | `bridge`                   | Sets the type of container networking to use        |
-| [`ZWIFT_UID`](#zwift_uid)                                 | `$(id -u)`                 | Sets the UID that Zwift will run as                 |
-| [`ZWIFT_GID`](#zwift_gid)                                 | `$(id -g)`                 | Sets the GID that Zwift will run as                 |
 | [`VGA_DEVICE_FLAG`](#vga_device_flag)                     |                            | Override container GPU/device flags                 |
 | [`PRIVILEGED_CONTAINER`](#privileged_container)           | `0`                        | If set to `1`, run the container in privileged mode |
 
@@ -666,52 +664,6 @@ Configure how the container connects to the Internet.
 | Default value     | `bridge`                             |
 | Commandline usage | `NETWORKING="host" zwift`            |
 | Config file usage | `NETWORKING="host"`                  |
-
----
-
-### `ZWIFT_UID`
-
-See also [`ZWIFT_GID`](#zwift_gid), [Remap User UID/GID](../../advanced/remap-user-id).
-
-Use this option to launch Zwift from a different user id.
-
-| Item              | Description              |
-|:------------------|:-------------------------|
-| Allowed values    | number                   |
-| Default value     | `$(id -u)`               |
-| Commandline usage | `ZWIFT_UID="1001" zwift` |
-| Config file usage | `ZWIFT_UID="1001"`       |
-
-{: .warning }
-> It is strongly discouraged to use a `ZWIFT_UID` that is different from your user uid. If you decide to do so anyway, know
-> that:
->
-> - It does not work with podman
-> - It does not work with Wayland
-> - Cats and dogs may start living together
-
----
-
-### `ZWIFT_GID`
-
-See also [`ZWIFT_UID`](#zwift_uid), [Remap User UID/GID](../../advanced/remap-user-id).
-
-Use this option to launch Zwift from a different group id.
-
-| Item              | Description              |
-|:------------------|:-------------------------|
-| Allowed values    | number                   |
-| Default value     | `$(id -g)`               |
-| Commandline usage | `ZWIFT_GID="1001" zwift` |
-| Config file usage | `ZWIFT_GID="1001"`       |
-
-{: .warning }
-> It is strongly discouraged to use a `ZWIFT_GID` that is different from your user gid. If you decide to do so anyway, know
-> that:
->
-> - It does not work with podman
-> - It does not work with Wayland
-> - Cats and dogs may start living together
 
 ---
 

--- a/flake.nix
+++ b/flake.nix
@@ -30,8 +30,6 @@
           zwiftNoGameMode,
           wineExperimentalWayland,
           networking,
-          zwiftUid,
-          zwiftGid,
           vgaDeviceFlag,
           debug,
           verbosity,
@@ -77,8 +75,6 @@
               wineExperimentalWayland != ""
             ) "export WINE_EXPERIMENTAL_WAYLAND=${wineExperimentalWayland}"}
             ${pkgs.lib.optionalString (networking != "") "export NETWORKING='${networking}'"}
-            ${pkgs.lib.optionalString (zwiftUid != "") "export ZWIFT_UID='${zwiftUid}'"}
-            ${pkgs.lib.optionalString (zwiftGid != "") "export ZWIFT_GID='${zwiftGid}'"}
             ${pkgs.lib.optionalString (debug != "") "export DEBUG=${debug}"}
             ${pkgs.lib.optionalString (verbosity != "") "export VERBOSITY='${verbosity}'"}
             ${pkgs.lib.optionalString (vgaDeviceFlag != "") "export VGA_DEVICE_FLAG='${vgaDeviceFlag}'"}
@@ -201,14 +197,6 @@
                 type = str;
                 default = "";
               };
-              zwiftUid = mkOption {
-                type = str;
-                default = "";
-              };
-              zwiftGid = mkOption {
-                type = str;
-                default = "";
-              };
               vgaDeviceFlag = mkOption {
                 type = str;
                 default = "";
@@ -250,8 +238,6 @@
                       zwiftScreenshotsDir
                       zwiftOverrideResolution
                       networking
-                      zwiftUid
-                      zwiftGid
                       vgaDeviceFlag
                       verbosity
                       ;

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,6 @@
 ARG DEBIAN_VERSION=trixie
+ARG USER_UID=1000
+ARG USER_GID=1000
 
 FROM rust:1.90-slim AS build-runfromprocess
 
@@ -27,6 +29,8 @@ FROM debian:${DEBIAN_VERSION}-slim AS wine-base
 # make sure to add "=" to the start, comment out for latest
 #    WINE_VERSION="=9.9~bookworm-1"
 ARG DEBIAN_VERSION
+ARG USER_UID
+ARG USER_GID
 ARG WINE_BRANCH="devel"
 ARG WINE_VERSION="=9.9~${DEBIAN_VERSION}-1"
 ARG WINETRICKS_VERSION=20240105
@@ -81,7 +85,8 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib/i386-linux-gnu:/usr/local
 COPY pulse-client.conf /etc/pulse/client.conf
 
 # Run as a regular user instead of root
-RUN adduser --disabled-password --gecos '' user
+RUN addgroup --gid ${USER_GID} user \
+ && adduser --uid ${USER_UID} --gid ${USER_GID} --disabled-password --comment '' user
 USER user
 
 FROM wine-base

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -38,7 +38,6 @@ ARG WINETRICKS_VERSION=20240105
 # - libegl1 and libgl1 for GL library
 # - libvulkan1 for vulkan loader library
 # - procps for pgrep
-# - sudo for normal user installation
 # - wget for downloading winehq key
 # - winbind for ntml_auth required by zwift/wine
 # - xdg-utils seems to be a dependency of wayland
@@ -52,7 +51,6 @@ RUN dpkg --add-architecture i386 \
         libgl1 \
         libvulkan1 \
         procps \
-        sudo \
         wget \
         winbind \
         xdg-utils \
@@ -72,11 +70,8 @@ RUN wget -qO /etc/apt/trusted.gpg.d/winehq.asc https://dl.winehq.org/wine-builds
  && wget -qO /usr/local/bin/winetricks https://raw.githubusercontent.com/Winetricks/winetricks/${WINETRICKS_VERSION}/src/winetricks \
  && chmod +x /usr/local/bin/winetricks
 
-# Add user with root privileges and make nvidia libraries discoverable
-RUN adduser --disabled-password --gecos '' user \
- && usermod -aG sudo user \
- && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
- && echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf \
+# Make nvidia libraries discoverable
+RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf \
  && echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
 
 # Required for non-glvnd setups
@@ -84,6 +79,10 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib/i386-linux-gnu:/usr/local
 
 # Configure audio driver
 COPY pulse-client.conf /etc/pulse/client.conf
+
+# Run as a regular user instead of root
+RUN adduser --disabled-password --gecos '' user
+USER user
 
 FROM wine-base
 
@@ -101,7 +100,5 @@ COPY --chmod=755 update_zwift.sh /bin/update_zwift.sh
 COPY --chmod=755 run_zwift.sh /bin/run_zwift.sh
 COPY --chmod=755 zwift-auth.sh /bin/zwift-auth
 COPY --chmod=755 --from=build-runfromprocess /usr/src/target/x86_64-pc-windows-gnu/release/runfromprocess-rs.exe /bin/runfromprocess-rs.exe
-
-USER user
 
 ENTRYPOINT ["entrypoint"]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -74,19 +74,26 @@ RUN wget -qO /etc/apt/trusted.gpg.d/winehq.asc https://dl.winehq.org/wine-builds
  && wget -qO /usr/local/bin/winetricks https://raw.githubusercontent.com/Winetricks/winetricks/${WINETRICKS_VERSION}/src/winetricks \
  && chmod +x /usr/local/bin/winetricks
 
-# Make nvidia libraries discoverable
-RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf \
- && echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
-
-# Required for non-glvnd setups
-ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib/i386-linux-gnu:/usr/local/nvidia/lib:/usr/local/nvidia/lib64
-
-# Configure audio driver
+# Add audio driver config file
 COPY pulse-client.conf /etc/pulse/client.conf
 
-# Run as a regular user instead of root
+# Various configuration
+# - Create user
+# - Create runtime directory
+# - Update audio driver config file
+# - Make nvidia libraries discoverable
 RUN addgroup --gid ${USER_GID} user \
- && adduser --uid ${USER_UID} --gid ${USER_GID} --disabled-password --comment '' user
+ && adduser --uid ${USER_UID} --gid ${USER_GID} --disabled-password --comment '' user \
+ && sed -i "s|/run/user/1000|/run/user/${USER_UID}|g" /etc/pulse/client.conf \
+ && mkdir -p /run/user/${USER_UID} \
+ && chown -R user:user /run/user/${USER_UID} \
+ && echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf \
+ && echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
+
+# Make nvidia libraries discoverable (Required for non-glvnd setups)
+ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib/i386-linux-gnu:/usr/local/nvidia/lib:/usr/local/nvidia/lib64
+
+# Run as a regular user instead of root
 USER user
 
 FROM wine-base

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -35,7 +35,6 @@ ARG WINETRICKS_VERSION=20240105
 # - ca-certificates for wget and curl
 # - curl used in zwift authentication script
 # - gamemode for freedesktop screensaver inhibit
-# - gosu for invoking scripts in entrypoint
 # - libegl1 and libgl1 for GL library
 # - libvulkan1 for vulkan loader library
 # - procps for pgrep
@@ -49,7 +48,6 @@ RUN dpkg --add-architecture i386 \
         ca-certificates \
         curl \
         gamemode \
-        gosu \
         libegl1 \
         libgl1 \
         libvulkan1 \
@@ -74,10 +72,10 @@ RUN wget -qO /etc/apt/trusted.gpg.d/winehq.asc https://dl.winehq.org/wine-builds
  && wget -qO /usr/local/bin/winetricks https://raw.githubusercontent.com/Winetricks/winetricks/${WINETRICKS_VERSION}/src/winetricks \
  && chmod +x /usr/local/bin/winetricks
 
-# Create passwordless user and make nvidia libraries discoverable
+# Add user with root privileges and make nvidia libraries discoverable
 RUN adduser --disabled-password --gecos '' user \
- && adduser user sudo \
- && echo '%SUDO ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
+ && usermod -aG sudo user \
+ && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
  && echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf \
  && echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
 
@@ -103,5 +101,7 @@ COPY --chmod=755 update_zwift.sh /bin/update_zwift.sh
 COPY --chmod=755 run_zwift.sh /bin/run_zwift.sh
 COPY --chmod=755 zwift-auth.sh /bin/zwift-auth
 COPY --chmod=755 --from=build-runfromprocess /usr/src/target/x86_64-pc-windows-gnu/release/runfromprocess-rs.exe /bin/runfromprocess-rs.exe
+
+USER user
 
 ENTRYPOINT ["entrypoint"]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -91,8 +91,8 @@ COPY pulse-client.conf /etc/pulse/client.conf
 # - Create runtime directory
 # - Update audio driver config file
 # - Make nvidia libraries discoverable
-RUN addgroup --gid ${USER_GID} user \
- && adduser --uid ${USER_UID} --gid ${USER_GID} --disabled-password --comment '' user \
+RUN groupadd --gid ${USER_GID} user \
+ && useradd --uid ${USER_UID} --gid ${USER_GID} --create-home --shell /bin/bash --no-log-init user \
  && sed -i "s|/run/user/1000|/run/user/${USER_UID}|g" /etc/pulse/client.conf \
  && mkdir -p /run/user/${USER_UID} \
  && chown -R user:user /run/user/${USER_UID} \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -79,9 +79,8 @@ RUN wget -qO /etc/apt/trusted.gpg.d/winehq.asc https://dl.winehq.org/wine-builds
 # Download winetricks
 ADD --checksum=sha256:${WINETRICKS_CHECKSUM} --chmod=755 https://raw.githubusercontent.com/Winetricks/winetricks/${WINETRICKS_VERSION}/src/winetricks /usr/local/bin/
 
-# Create passwordless user and make nvidia libraries discoverable
-RUN adduser --disabled-password --gecos '' user \
- && echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf \
+# Make nvidia libraries discoverable
+RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf \
  && echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
 
 # Required for non-glvnd setups
@@ -89,6 +88,10 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib/i386-linux-gnu:/usr/local
 
 # Configure audio driver
 COPY pulse-client.conf /etc/pulse/client.conf
+
+# Run as a regular user instead of root
+RUN adduser --disabled-password --gecos '' user
+USER user
 
 FROM wine-base
 
@@ -110,7 +113,5 @@ COPY --chmod=755 update_zwift.sh /bin/update_zwift.sh
 COPY --chmod=755 run_zwift.sh /bin/run_zwift.sh
 COPY --chmod=755 zwift-auth.sh /bin/zwift-auth
 COPY --from=build-runfromprocess /usr/src/target/x86_64-pc-windows-gnu/release/runfromprocess-rs.exe /bin/runfromprocess-rs.exe
-
-USER user
 
 ENTRYPOINT ["entrypoint"]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -38,7 +38,6 @@ ARG WINETRICKS_CHECKSUM=431f82fc74000e6c864409f1d8fb495d696c03928808e3e8acffc451
 # - cabextract for winetricks
 # - curl used in zwift authentication script
 # - gamemode for freedesktop screensaver inhibit
-# - gosu for invoking scripts in entrypoint
 # - libegl1 and libgl1 for GL library
 # - libvulkan1 for vulkan loader library
 # - procps for pgrep
@@ -53,7 +52,6 @@ RUN dpkg --add-architecture i386 \
         cabextract \
         curl \
         gamemode \
-        gosu \
         libegl1 \
         libgl1 \
         libgamemode0.i386 \
@@ -112,5 +110,7 @@ COPY --chmod=755 update_zwift.sh /bin/update_zwift.sh
 COPY --chmod=755 run_zwift.sh /bin/run_zwift.sh
 COPY --chmod=755 zwift-auth.sh /bin/zwift-auth
 COPY --from=build-runfromprocess /usr/src/target/x86_64-pc-windows-gnu/release/runfromprocess-rs.exe /bin/runfromprocess-rs.exe
+
+USER user
 
 ENTRYPOINT ["entrypoint"]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -83,19 +83,26 @@ RUN wget -qO /etc/apt/trusted.gpg.d/winehq.asc https://dl.winehq.org/wine-builds
 # Download winetricks
 ADD --checksum=sha256:${WINETRICKS_CHECKSUM} --chmod=755 https://raw.githubusercontent.com/Winetricks/winetricks/${WINETRICKS_VERSION}/src/winetricks /usr/local/bin/
 
-# Make nvidia libraries discoverable
-RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf \
- && echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
-
-# Required for non-glvnd setups
-ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib/i386-linux-gnu:/usr/local/nvidia/lib:/usr/local/nvidia/lib64
-
-# Configure audio driver
+# Add audio driver config file
 COPY pulse-client.conf /etc/pulse/client.conf
 
-# Run as a regular user instead of root
+# Various configuration
+# - Create user
+# - Create runtime directory
+# - Update audio driver config file
+# - Make nvidia libraries discoverable
 RUN addgroup --gid ${USER_GID} user \
- && adduser --uid ${USER_UID} --gid ${USER_GID} --disabled-password --comment '' user
+ && adduser --uid ${USER_UID} --gid ${USER_GID} --disabled-password --comment '' user \
+ && sed -i "s|/run/user/1000|/run/user/${USER_UID}|g" /etc/pulse/client.conf \
+ && mkdir -p /run/user/${USER_UID} \
+ && chown -R user:user /run/user/${USER_UID} \
+ && echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf \
+ && echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
+
+# Make nvidia libraries discoverable (Required for non-glvnd setups)
+ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib/i386-linux-gnu:/usr/local/nvidia/lib:/usr/local/nvidia/lib64
+
+# Run as a regular user instead of root
 USER user
 
 FROM wine-base

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,6 @@
 ARG DEBIAN_VERSION=trixie
+ARG USER_UID=1000
+ARG USER_GID=1000
 
 FROM rust:1.98.0-slim-trixie AS build-runfromprocess
 
@@ -28,6 +30,8 @@ FROM debian:${DEBIAN_VERSION}-slim AS wine-base
 # - 20260125 : webview2 in zwift launcher works
 # - 20240105 : first version used in this Dockerfile
 ARG DEBIAN_VERSION
+ARG USER_UID
+ARG USER_GID
 ARG WINE_BRANCH="devel"
 ARG WINE_VERSION="=9.9~${DEBIAN_VERSION}-1"
 ARG WINETRICKS_VERSION=20260125
@@ -90,7 +94,8 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib/i386-linux-gnu:/usr/local
 COPY pulse-client.conf /etc/pulse/client.conf
 
 # Run as a regular user instead of root
-RUN adduser --disabled-password --gecos '' user
+RUN addgroup --gid ${USER_GID} user \
+ && adduser --uid ${USER_UID} --gid ${USER_GID} --disabled-password --comment '' user
 USER user
 
 FROM wine-base

--- a/src/build-image.sh
+++ b/src/build-image.sh
@@ -125,7 +125,6 @@ container_args=(
 
 # Initialize user ids
 host_uid="${UID}"
-host_gid="$(id -g)"
 if [[ ${CONTAINER_TOOL} == "podman" ]]; then
     # Podman maps the local user into the container as uid/gid 1000 (the container's user),
     # consistent with zwift.sh. Using the host uid/gid here causes a uid mismatch at runtime.
@@ -133,10 +132,6 @@ if [[ ${CONTAINER_TOOL} == "podman" ]]; then
     container_args+=(--userns="keep-id:uid=1000,gid=1000")
 else
     container_uid="${host_uid}"
-    container_args+=(
-        -e HOST_UID="${host_uid}"
-        -e HOST_GID="${host_gid}"
-    )
 fi
 
 # Configure window manager

--- a/src/build-image.sh
+++ b/src/build-image.sh
@@ -108,6 +108,10 @@ msgbox info "Image will be called ${IMAGE}"
 ###############################
 ##### Basic configuration #####
 
+# Create array for build arguments
+declare -a build_args
+build_args=()
+
 # Create array for container arguments
 declare -a container_args
 container_args=(
@@ -125,6 +129,7 @@ container_args=(
 
 # Initialize user ids
 host_uid="${UID}"
+host_gid="$(id -g)"
 if [[ ${CONTAINER_TOOL} == "podman" ]]; then
     # Podman maps the local user into the container as uid/gid 1000 (the container's user),
     # consistent with zwift.sh. Using the host uid/gid here causes a uid mismatch at runtime.
@@ -132,6 +137,10 @@ if [[ ${CONTAINER_TOOL} == "podman" ]]; then
     container_args+=(--userns="keep-id:uid=1000,gid=1000")
 else
     container_uid="${host_uid}"
+    build_args+=(
+        --build-arg USER_UID="${host_uid}"
+        --build-arg USER_GID="${host_gid}"
+    )
 fi
 
 # Configure window manager
@@ -186,7 +195,7 @@ cleanup() {
 trap cleanup EXIT
 
 msgbox info "Building image ${IMAGE}"
-if ${CONTAINER_TOOL} build --force-rm -t "${BUILD_NAME}" "${SCRIPT_DIR}"; then
+if ${CONTAINER_TOOL} build --force-rm "${build_args[@]}" -t "${BUILD_NAME}" "${SCRIPT_DIR}"; then
     msgbox ok "Successfully built image ${IMAGE}"
 else
     msgbox error "Failed to build image"

--- a/src/build-image.sh
+++ b/src/build-image.sh
@@ -73,9 +73,7 @@ readonly XAUTHORITY="${XAUTHORITY:-}"
 
 # Initialize script constants
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
-ZWIFT_UID="${UID}"
-ZWIFT_GID="$(id -g)"
-readonly SCRIPT_DIR ZWIFT_UID ZWIFT_GID
+readonly SCRIPT_DIR
 
 # Initialize CONTAINER_TOOL: Use podman if available
 msgbox info "Looking for container tool"
@@ -123,14 +121,22 @@ container_args=(
     -e VERBOSITY="${VERBOSITY}"
     -e COLORED_OUTPUT="${COLORED_OUTPUT_SUPPORTED}"
     -e CONTAINER_TOOL="${CONTAINER_TOOL}"
-    -e ZWIFT_UID="${ZWIFT_UID}"
-    -e ZWIFT_GID="${ZWIFT_GID}"
 )
 
+# Initialize user ids
+host_uid="${UID}"
+host_gid="$(id -g)"
 if [[ ${CONTAINER_TOOL} == "podman" ]]; then
     # Podman maps the local user into the container as uid/gid 1000 (the container's user),
     # consistent with zwift.sh. Using the host uid/gid here causes a uid mismatch at runtime.
-    container_args+=(--userns "keep-id:uid=1000,gid=1000")
+    container_uid=1000
+    container_args+=(--userns="keep-id:uid=1000,gid=1000")
+else
+    container_uid="${host_uid}"
+    container_args+=(
+        -e HOST_UID="${host_uid}"
+        -e HOST_GID="${host_gid}"
+    )
 fi
 
 # Configure window manager
@@ -145,8 +151,8 @@ container_args+=(
 )
 if [[ -n ${XAUTHORITY} ]]; then
     container_args+=(
-        -e XAUTHORITY="${XAUTHORITY}"
-        -v "${XAUTHORITY}:${XAUTHORITY}"
+        -e XAUTHORITY="${XAUTHORITY//${host_uid}/${container_uid}}"
+        -v "${XAUTHORITY}:${XAUTHORITY//${host_uid}/${container_uid}}"
     )
 elif command_exists xhost && xhost +local: > /dev/null; then
     msgbox ok "Container X11 access provided through xhost"

--- a/src/build-image.sh
+++ b/src/build-image.sh
@@ -101,6 +101,10 @@ msgbox info "Image will be called ${IMAGE}"
 ###############################
 ##### Basic configuration #####
 
+# Create array for build arguments
+declare -a build_args
+build_args=()
+
 # Create array for container arguments
 declare -a container_args
 container_args=(
@@ -118,6 +122,7 @@ container_args=(
 
 # Initialize user ids
 host_uid="${UID}"
+host_gid="$(id -g)"
 if [[ ${CONTAINER_TOOL} == "podman" ]]; then
     # Podman maps the local user into the container as uid/gid 1000 (the container's user),
     # consistent with zwift.sh. Using the host uid/gid here causes a uid mismatch at runtime.
@@ -125,6 +130,10 @@ if [[ ${CONTAINER_TOOL} == "podman" ]]; then
     container_args+=(--userns="keep-id:uid=1000,gid=1000")
 else
     container_uid="${host_uid}"
+    build_args+=(
+        --build-arg USER_UID="${host_uid}"
+        --build-arg USER_GID="${host_gid}"
+    )
 fi
 
 # Configure window manager
@@ -183,7 +192,7 @@ cleanup() {
 trap cleanup EXIT
 
 msgbox info "Building image ${IMAGE}"
-if ${CONTAINER_TOOL} build --force-rm -t "${BUILD_NAME}" "${SCRIPT_DIR}"; then
+if ${CONTAINER_TOOL} build --force-rm "${build_args[@]}" -t "${BUILD_NAME}" "${SCRIPT_DIR}"; then
     msgbox ok "Successfully built image ${IMAGE}"
 else
     msgbox error "Failed to build image! 😭"

--- a/src/build-image.sh
+++ b/src/build-image.sh
@@ -65,9 +65,7 @@ readonly XAUTHORITY="${XAUTHORITY:-}"
 
 # Initialize script constants
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
-ZWIFT_UID="${UID}"
-ZWIFT_GID="$(id -g)"
-readonly SCRIPT_DIR ZWIFT_UID ZWIFT_GID
+readonly SCRIPT_DIR
 
 # Initialize CONTAINER_TOOL: Use podman if available
 msgbox info "Looking for container tool"
@@ -116,14 +114,22 @@ container_args=(
     -e VERBOSITY="${VERBOSITY}"
     -e COLORED_OUTPUT="${COLORED_OUTPUT_SUPPORTED}"
     -e CONTAINER_TOOL="${CONTAINER_TOOL}"
-    -e ZWIFT_UID="${ZWIFT_UID}"
-    -e ZWIFT_GID="${ZWIFT_GID}"
 )
 
+# Initialize user ids
+host_uid="${UID}"
+host_gid="$(id -g)"
 if [[ ${CONTAINER_TOOL} == "podman" ]]; then
     # Podman maps the local user into the container as uid/gid 1000 (the container's user),
     # consistent with zwift.sh. Using the host uid/gid here causes a uid mismatch at runtime.
-    container_args+=(--userns "keep-id:uid=1000,gid=1000")
+    container_uid=1000
+    container_args+=(--userns="keep-id:uid=1000,gid=1000")
+else
+    container_uid="${host_uid}"
+    container_args+=(
+        -e HOST_UID="${host_uid}"
+        -e HOST_GID="${host_gid}"
+    )
 fi
 
 # Configure window manager
@@ -142,8 +148,8 @@ container_args+=(
 )
 if [[ -n ${XAUTHORITY} ]]; then
     container_args+=(
-        -e XAUTHORITY="${XAUTHORITY}"
-        -v "${XAUTHORITY}:${XAUTHORITY}"
+        -e XAUTHORITY="${XAUTHORITY//${host_uid}/${container_uid}}"
+        -v "${XAUTHORITY}:${XAUTHORITY//${host_uid}/${container_uid}}"
     )
 elif command_exists xhost && xhost +local: > /dev/null; then
     msgbox ok "Container X11 access provided through xhost"

--- a/src/build-image.sh
+++ b/src/build-image.sh
@@ -118,7 +118,6 @@ container_args=(
 
 # Initialize user ids
 host_uid="${UID}"
-host_gid="$(id -g)"
 if [[ ${CONTAINER_TOOL} == "podman" ]]; then
     # Podman maps the local user into the container as uid/gid 1000 (the container's user),
     # consistent with zwift.sh. Using the host uid/gid here causes a uid mismatch at runtime.
@@ -126,10 +125,6 @@ if [[ ${CONTAINER_TOOL} == "podman" ]]; then
     container_args+=(--userns="keep-id:uid=1000,gid=1000")
 else
     container_uid="${host_uid}"
-    container_args+=(
-        -e HOST_UID="${host_uid}"
-        -e HOST_GID="${host_gid}"
-    )
 fi
 
 # Configure window manager

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -22,14 +22,12 @@ else
 fi
 
 readonly VERBOSITY="${VERBOSITY:-1}"
-readonly ZWIFT_UID="${ZWIFT_UID:-$(id -u user)}"
-readonly ZWIFT_GID="${ZWIFT_GID:-$(id -g user)}"
+readonly HOST_UID="${HOST_UID:-$(id -u user)}"
+readonly HOST_GID="${HOST_GID:-$(id -g user)}"
 readonly WINE_EXPERIMENTAL_WAYLAND="${WINE_EXPERIMENTAL_WAYLAND:-0}"
 readonly CONTAINER_TOOL="${CONTAINER_TOOL:?}"
 
-readonly WINE_USER_HOME="/home/user/.wine/drive_c/users/user"
 readonly ZWIFT_HOME="/home/user/.wine/drive_c/Program Files (x86)/Zwift"
-readonly ZWIFT_DOCS="${WINE_USER_HOME}/AppData/Local/Zwift"
 
 msgbox() {
     local type="${1:?}" # Type: info, ok, warning, error, debug
@@ -86,43 +84,37 @@ fi
 
 declare -a startup_cmd
 startup_cmd=(/bin/run_zwift.sh)
-update_required=0
 
 if is_empty_directory "${ZWIFT_HOME}"; then
     startup_cmd=(/bin/update_zwift.sh --install)
-    update_required=1
 elif [[ ${1:-} == "--update" ]]; then
     startup_cmd=(/bin/update_zwift.sh)
-    update_required=1
 fi
 
-######################################
-##### Change ownership if needed #####
+#################################################
+##### Add container user to host user group #####
 
 if [[ ${CONTAINER_TOOL} == "docker" ]]; then
-    # with docker the container is launched as root
-    # here we update ids and ownership so zwift can be launched as user instead
+    # docker does not support remapping container user to host user out of the box
 
-    user_uid="$(id -u user)"
-    user_gid="$(id -g user)"
+    container_uid="$(id -u user)"
+    container_gid="$(id -g user)"
 
     should_change_user_ids() {
-        # ids should be updated if ZWIFT_UID:ZWIFT_GID is different from from user uid:gid
+        # ids should be updated if HOST_UID:HOST_GID is different from from user uid:gid
         # returns 0 if ids should be changed, 1 if not, so it can be used in an if
 
         local result=1
 
-        if [[ ! ${ZWIFT_UID} =~ ^[0-9]+$ ]]; then
-            msgbox warning "Ignoring ZWIFT_UID '${ZWIFT_UID}' because it is not a number"
-        elif [[ ${user_uid} -ne ${ZWIFT_UID} ]]; then
-            user_uid="${ZWIFT_UID}"
+        if [[ ! ${HOST_UID} =~ ^[0-9]+$ ]]; then
+            msgbox warning "Ignoring HOST_UID '${HOST_UID}' because it is not a number"
+        elif [[ ${container_uid} -ne ${HOST_UID} ]]; then
             result=0
         fi
 
-        if [[ ! ${ZWIFT_GID} =~ ^[0-9]+$ ]]; then
-            msgbox warning "Ignoring ZWIFT_GID '${ZWIFT_GID}' because it is not a number"
-        elif [[ ${user_gid} -ne ${ZWIFT_GID} ]]; then
-            user_gid="${ZWIFT_GID}"
+        if [[ ! ${HOST_GID} =~ ^[0-9]+$ ]]; then
+            msgbox warning "Ignoring HOST_GID '${HOST_GID}' because it is not a number"
+        elif [[ ${container_gid} -ne ${HOST_GID} ]]; then
             result=0
         fi
 
@@ -130,41 +122,15 @@ if [[ ${CONTAINER_TOOL} == "docker" ]]; then
     }
 
     change_user_ids() {
-        usermod -ou "${user_uid}" user || return 1
-        groupmod -og "${user_gid}" user || return 1
-        mkdir -p "/run/user/${user_uid}" || return 1
-        chown -R user:user "/run/user/${user_uid}" || return 1
-        sed -i "s|/run/user/1000|/run/user/${user_uid}|g" /etc/pulse/client.conf || return 1
-    }
-
-    ownership_needs_update() {
-        # Quick check: if the top-level directory is already owned by user:user, assume everything is fine
-        # This avoids a costly recursive find on every normal startup
-        local target="${1:?}"
-        local result
-        [[ -d ${target} ]] && result="$(find "${target}" -maxdepth 1 \( ! -user user -o ! -group user \) -print 2> /dev/null)" && [[ -n ${result} ]]
-    }
-
-    update_ownership() {
-        local target
-        if [[ ${update_required} -eq 1 ]]; then
-            target="/home/user"
-        else
-            target="${ZWIFT_DOCS}"
-        fi
-
-        if ! ownership_needs_update "${target}"; then
-            msgbox ok "Ownership already correct, skipping"
-            return 0
-        fi
-
-        # Only chown files that actually need it, rather than blindly recursing everything
-        msgbox info "Updating ownership of files in ${target} (this may take a while on first run)..."
-        find "${target}" \( ! -user user -o ! -group user \) -exec chown user:user {} + || return 1
+        sudo usermod -ou "${HOST_UID}" user || return 1
+        sudo groupmod -og "${HOST_GID}" user || return 1
+        sudo mkdir -p "/run/user/${HOST_UID}" || return 1
+        sudo chown -R user:user "/run/user/${HOST_UID}" || return 1
+        sudo sed -i "s|/run/user/1000|/run/user/${user_uid}|g" /etc/pulse/client.conf || return 1
     }
 
     if should_change_user_ids; then
-        msgbox info "Changing user ids to ${user_uid}:${user_gid}"
+        msgbox info "Changing user ids to ${HOST_UID}:${HOST_GID}"
         if change_user_ids; then
             msgbox ok "Changed user ids"
         else
@@ -172,19 +138,14 @@ if [[ ${CONTAINER_TOOL} == "docker" ]]; then
             exit 1
         fi
     fi
-
-    msgbox info "Checking file ownership"
-    if update_ownership; then
-        msgbox ok "File ownership is correct"
-    else
-        msgbox error "Failed to update file ownership"
-        exit 1
-    fi
-
-    startup_cmd=(gosu user:user "${startup_cmd[@]}")
 fi
 
 #########################################
 ##### Launch update or start script #####
+
+actual_user="$(whoami)"
+actual_uid="$(id -u "${actual_user}")"
+actual_gid="$(id -g "${actual_user}")"
+msgbox debug "Running as ${actual_user} (uid=${actual_uid}, gid=${actual_gid})"
 
 "${startup_cmd[@]}"

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -54,6 +54,10 @@ msgbox() {
     esac
 }
 
+is_user_root() {
+    [[ ${EUID} -eq 0 ]]
+}
+
 is_empty_directory() {
     local directory="${1:?}"
     if [[ ! -d ${directory} ]]; then
@@ -64,38 +68,18 @@ is_empty_directory() {
     ! contents="$(ls -A "${directory}" 2> /dev/null)" || [[ -z ${contents} ]]
 }
 
-###########################
-##### Configure Zwift #####
-
-if ! mkdir -p "${ZWIFT_HOME}" || ! cd "${ZWIFT_HOME}"; then
-    msgbox error "Zwift home directory '${ZWIFT_HOME}' does not exist or is not accessible!"
-    exit 1
-fi
-
-# If Wayland Experimental need to blank DISPLAY here to enable Wayland.
-# NOTE: DISPLAY must be unset here before run_zwift to work
-#       Registry entries are set in the container install or won't work.
-if [[ ${WINE_EXPERIMENTAL_WAYLAND} -eq 1 ]]; then
-    unset DISPLAY
-fi
-
-############################################
-##### Clean install, update or launch? #####
-
-declare -a startup_cmd
-startup_cmd=(/bin/run_zwift.sh)
-
-if is_empty_directory "${ZWIFT_HOME}"; then
-    startup_cmd=(/bin/update_zwift.sh --install)
-elif [[ ${1:-} == "--update" ]]; then
-    startup_cmd=(/bin/update_zwift.sh)
-fi
-
-#################################################
-##### Add container user to host user group #####
-
-if [[ ${CONTAINER_TOOL} == "docker" ]]; then
+remap_user() {
     # docker does not support remapping container user to host user out of the box
+
+    if ! is_user_root; then
+        msgbox error "Must be root to remap user"
+        return 1
+    fi
+
+    if [[ ${CONTAINER_TOOL} != "docker" ]]; then
+        msgbox error "User should only be remapped when using docker"
+        return 1
+    fi
 
     container_uid="$(id -u user)"
     container_gid="$(id -g user)"
@@ -122,11 +106,11 @@ if [[ ${CONTAINER_TOOL} == "docker" ]]; then
     }
 
     change_user_ids() {
-        sudo usermod -ou "${HOST_UID}" user || return 1
-        sudo groupmod -og "${HOST_GID}" user || return 1
-        sudo mkdir -p "/run/user/${HOST_UID}" || return 1
-        sudo chown -R user:user "/run/user/${HOST_UID}" || return 1
-        sudo sed -i "s|/run/user/1000|/run/user/${user_uid}|g" /etc/pulse/client.conf || return 1
+        usermod -ou "${HOST_UID}" user || return 1
+        groupmod -og "${HOST_GID}" user || return 1
+        mkdir -p "/run/user/${HOST_UID}" || return 1
+        chown -R user:user "/run/user/${HOST_UID}" || return 1
+        sed -i "s|/run/user/1000|/run/user/${HOST_UID}|g" /etc/pulse/client.conf || return 1
     }
 
     if should_change_user_ids; then
@@ -135,10 +119,12 @@ if [[ ${CONTAINER_TOOL} == "docker" ]]; then
             msgbox ok "Changed user ids"
         else
             msgbox error "Failed to change user ids"
-            exit 1
+            return 1
         fi
+    else
+        msgbox info "Nothing to do, user ids are already ${HOST_UID}:${HOST_GID}"
     fi
-fi
+}
 
 #########################################
 ##### Launch update or start script #####
@@ -147,5 +133,45 @@ actual_user="$(whoami)"
 actual_uid="$(id -u "${actual_user}")"
 actual_gid="$(id -g "${actual_user}")"
 msgbox debug "Running as ${actual_user} (uid=${actual_uid}, gid=${actual_gid})"
+
+if [[ ${1:-} == "--remap-user" ]]; then
+    msgbox info "Remapping container user to host user"
+    if remap_user; then
+        msgbox ok "Remapped container user to host user"
+        exit 0
+    else
+        msgbox error "Failed to remap container user to host user"
+        exit 1
+    fi
+fi
+
+msgbox info "Starting or installing Zwift"
+
+if is_user_root; then
+    msgbox error "Cannot run or install Zwift as root!"
+    exit 1
+fi
+
+if ! mkdir -p "${ZWIFT_HOME}" || ! cd "${ZWIFT_HOME}"; then
+    msgbox error "Zwift home directory '${ZWIFT_HOME}' does not exist or is not accessible!"
+    exit 1
+fi
+
+# If Wayland Experimental need to blank DISPLAY here to enable Wayland.
+# NOTE: DISPLAY must be unset here before run_zwift to work
+#       Registry entries are set in the container install or won't work.
+if [[ ${WINE_EXPERIMENTAL_WAYLAND} -eq 1 ]]; then
+    msgbox info "Using Wayland, unsetting DISPLAY environment variable"
+    unset DISPLAY
+fi
+
+declare -a startup_cmd
+startup_cmd=(/bin/run_zwift.sh)
+
+if is_empty_directory "${ZWIFT_HOME}"; then
+    startup_cmd=(/bin/update_zwift.sh --install)
+elif [[ ${1:-} == "--update" ]]; then
+    startup_cmd=(/bin/update_zwift.sh)
+fi
 
 "${startup_cmd[@]}"

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -22,8 +22,6 @@ else
 fi
 
 readonly VERBOSITY="${VERBOSITY:-1}"
-readonly HOST_UID="${HOST_UID:-$(id -u user)}"
-readonly HOST_GID="${HOST_GID:-$(id -g user)}"
 readonly WINE_EXPERIMENTAL_WAYLAND="${WINE_EXPERIMENTAL_WAYLAND:-0}"
 readonly CONTAINER_TOOL="${CONTAINER_TOOL:?}"
 
@@ -68,84 +66,15 @@ is_empty_directory() {
     ! contents="$(ls -A "${directory}" 2> /dev/null)" || [[ -z ${contents} ]]
 }
 
-remap_user() {
-    # docker does not support remapping container user to host user out of the box
-
-    if ! is_user_root; then
-        msgbox error "Must be root to remap user"
-        return 1
-    fi
-
-    if [[ ${CONTAINER_TOOL} != "docker" ]]; then
-        msgbox error "User should only be remapped when using docker"
-        return 1
-    fi
-
-    container_uid="$(id -u user)"
-    container_gid="$(id -g user)"
-
-    should_change_user_ids() {
-        # ids should be updated if HOST_UID:HOST_GID is different from from user uid:gid
-        # returns 0 if ids should be changed, 1 if not, so it can be used in an if
-
-        local result=1
-
-        if [[ ! ${HOST_UID} =~ ^[0-9]+$ ]]; then
-            msgbox warning "Ignoring HOST_UID '${HOST_UID}' because it is not a number"
-        elif [[ ${container_uid} -ne ${HOST_UID} ]]; then
-            result=0
-        fi
-
-        if [[ ! ${HOST_GID} =~ ^[0-9]+$ ]]; then
-            msgbox warning "Ignoring HOST_GID '${HOST_GID}' because it is not a number"
-        elif [[ ${container_gid} -ne ${HOST_GID} ]]; then
-            result=0
-        fi
-
-        return "${result}"
-    }
-
-    change_user_ids() {
-        usermod -ou "${HOST_UID}" user || return 1
-        groupmod -og "${HOST_GID}" user || return 1
-        mkdir -p "/run/user/${HOST_UID}" || return 1
-        chown -R user:user "/run/user/${HOST_UID}" || return 1
-        sed -i "s|/run/user/1000|/run/user/${HOST_UID}|g" /etc/pulse/client.conf || return 1
-    }
-
-    if should_change_user_ids; then
-        msgbox info "Changing user ids to ${HOST_UID}:${HOST_GID}"
-        if change_user_ids; then
-            msgbox ok "Changed user ids"
-        else
-            msgbox error "Failed to change user ids"
-            return 1
-        fi
-    else
-        msgbox info "Nothing to do, user ids are already ${HOST_UID}:${HOST_GID}"
-    fi
-}
-
 #########################################
 ##### Launch update or start script #####
+
+msgbox info "Starting or installing Zwift"
 
 actual_user="$(whoami)"
 actual_uid="$(id -u "${actual_user}")"
 actual_gid="$(id -g "${actual_user}")"
 msgbox debug "Running as ${actual_user} (uid=${actual_uid}, gid=${actual_gid})"
-
-if [[ ${1:-} == "--remap-user" ]]; then
-    msgbox info "Remapping container user to host user"
-    if remap_user; then
-        msgbox ok "Remapped container user to host user"
-        exit 0
-    else
-        msgbox error "Failed to remap container user to host user"
-        exit 1
-    fi
-fi
-
-msgbox info "Starting or installing Zwift"
 
 if is_user_root; then
     msgbox error "Cannot run or install Zwift as root!"

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -22,8 +22,8 @@ else
 fi
 
 readonly VERBOSITY="${VERBOSITY:-1}"
-readonly ZWIFT_UID="${ZWIFT_UID:-$(id -u user)}"
-readonly ZWIFT_GID="${ZWIFT_GID:-$(id -g user)}"
+readonly HOST_UID="${HOST_UID:-$(id -u user)}"
+readonly HOST_GID="${HOST_GID:-$(id -g user)}"
 readonly WINE_EXPERIMENTAL_WAYLAND="${WINE_EXPERIMENTAL_WAYLAND:-0}"
 readonly CONTAINER_TOOL="${CONTAINER_TOOL:?}"
 readonly ZWIFT_VOLUME="${ZWIFT_VOLUME:-}"
@@ -68,33 +68,30 @@ else
     startup_cmd=(/bin/run_zwift.sh)
 fi
 
-######################################
-##### Change ownership if needed #####
+#################################################
+##### Add container user to host user group #####
 
 if [[ ${CONTAINER_TOOL} == "docker" ]]; then
-    # with docker the container is launched as root
-    # here we update ids and ownership so zwift can be launched as user instead
+    # docker does not support remapping container user to host user out of the box
 
-    user_uid="$(id -u user)"
-    user_gid="$(id -g user)"
+    container_uid="$(id -u user)"
+    container_gid="$(id -g user)"
 
     should_change_user_ids() {
-        # ids should be updated if ZWIFT_UID:ZWIFT_GID is different from from user uid:gid
+        # ids should be updated if HOST_UID:HOST_GID is different from from user uid:gid
         # returns 0 if ids should be changed, 1 if not, so it can be used in an if
 
         local result=1
 
-        if [[ ! ${ZWIFT_UID} =~ ^[0-9]+$ ]]; then
-            msgbox warning "Ignoring ZWIFT_UID '${ZWIFT_UID}' because it is not a number"
-        elif [[ ${user_uid} -ne ${ZWIFT_UID} ]]; then
-            user_uid="${ZWIFT_UID}"
+        if [[ ! ${HOST_UID} =~ ^[0-9]+$ ]]; then
+            msgbox warning "Ignoring HOST_UID '${HOST_UID}' because it is not a number"
+        elif [[ ${container_uid} -ne ${HOST_UID} ]]; then
             result=0
         fi
 
-        if [[ ! ${ZWIFT_GID} =~ ^[0-9]+$ ]]; then
-            msgbox warning "Ignoring ZWIFT_GID '${ZWIFT_GID}' because it is not a number"
-        elif [[ ${user_gid} -ne ${ZWIFT_GID} ]]; then
-            user_gid="${ZWIFT_GID}"
+        if [[ ! ${HOST_GID} =~ ^[0-9]+$ ]]; then
+            msgbox warning "Ignoring HOST_GID '${HOST_GID}' because it is not a number"
+        elif [[ ${container_gid} -ne ${HOST_GID} ]]; then
             result=0
         fi
 
@@ -102,36 +99,15 @@ if [[ ${CONTAINER_TOOL} == "docker" ]]; then
     }
 
     change_user_ids() {
-        usermod -ou "${user_uid}" user || return 1
-        groupmod -og "${user_gid}" user || return 1
-        mkdir -p "/run/user/${user_uid}" || return 1
-        chown -R user:user "/run/user/${user_uid}" || return 1
-        sed -i "s|/run/user/1000|/run/user/${user_uid}|g" /etc/pulse/client.conf || return 1
-    }
-
-    ownership_needs_update() {
-        # Quick check: if the top-level directory is already owned by user:user, assume everything is fine
-        # This avoids a costly recursive find on every normal startup
-        local target="${1:?}"
-        local result
-        [[ -d ${target} ]] && result="$(find "${target}" -maxdepth 1 \( ! -user user -o ! -group user \) -print 2> /dev/null)" && [[ -n ${result} ]]
-    }
-
-    update_ownership() {
-        local target="${ZWIFT_VOLUME}"
-
-        if [[ -z ${target} ]] || ! ownership_needs_update "${target}"; then
-            msgbox ok "Ownership already correct, skipping"
-            return 0
-        fi
-
-        # Only chown files that actually need it, rather than blindly recursing everything
-        msgbox info "Updating ownership of files in ${target} (this may take a while on first run)..."
-        find "${target}" \( ! -user user -o ! -group user \) -exec chown user:user {} + || return 1
+        sudo usermod -ou "${HOST_UID}" user || return 1
+        sudo groupmod -og "${HOST_GID}" user || return 1
+        sudo mkdir -p "/run/user/${HOST_UID}" || return 1
+        sudo chown -R user:user "/run/user/${HOST_UID}" || return 1
+        sudo sed -i "s|/run/user/1000|/run/user/${container_uid}|g" /etc/pulse/client.conf || return 1
     }
 
     if should_change_user_ids; then
-        msgbox info "Changing user ids to ${user_uid}:${user_gid}"
+        msgbox info "Changing user ids to ${HOST_UID}:${HOST_GID}"
         if change_user_ids; then
             msgbox ok "Changed user ids"
         else
@@ -139,19 +115,14 @@ if [[ ${CONTAINER_TOOL} == "docker" ]]; then
             exit 1
         fi
     fi
-
-    msgbox info "Checking file ownership"
-    if update_ownership; then
-        msgbox ok "File ownership is correct"
-    else
-        msgbox error "Failed to update file ownership"
-        exit 1
-    fi
-
-    startup_cmd=(gosu user:user "${startup_cmd[@]}")
 fi
 
 #########################################
 ##### Launch update or start script #####
+
+actual_user="$(whoami)"
+actual_uid="$(id -u "${actual_user}")"
+actual_gid="$(id -g "${actual_user}")"
+msgbox debug "Running as ${actual_user} (uid=${actual_uid}, gid=${actual_gid})"
 
 "${startup_cmd[@]}"

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -22,11 +22,8 @@ else
 fi
 
 readonly VERBOSITY="${VERBOSITY:-1}"
-readonly HOST_UID="${HOST_UID:-$(id -u user)}"
-readonly HOST_GID="${HOST_GID:-$(id -g user)}"
 readonly WINE_EXPERIMENTAL_WAYLAND="${WINE_EXPERIMENTAL_WAYLAND:-0}"
 readonly CONTAINER_TOOL="${CONTAINER_TOOL:?}"
-readonly ZWIFT_VOLUME="${ZWIFT_VOLUME:-}"
 
 msgbox() {
     local type="${1:?}" # Type: info, ok, warning, error, debug
@@ -49,89 +46,16 @@ is_user_root() {
     [[ ${EUID} -eq 0 ]]
 }
 
-#################################################
-##### Add container user to host user group #####
-
-remap_user() {
-    # docker does not support remapping container user to host user out of the box
-
-    if ! is_user_root; then
-        msgbox error "Must be root to remap user"
-        return 1
-    fi
-
-    if [[ ${CONTAINER_TOOL} != "docker" ]]; then
-        msgbox error "User should only be remapped when using docker"
-        return 1
-    fi
-
-    container_uid="$(id -u user)"
-    container_gid="$(id -g user)"
-
-    should_change_user_ids() {
-        # ids should be updated if HOST_UID:HOST_GID is different from from user uid:gid
-        # returns 0 if ids should be changed, 1 if not, so it can be used in an if
-
-        local result=1
-
-        if [[ ! ${HOST_UID} =~ ^[0-9]+$ ]]; then
-            msgbox warning "Ignoring HOST_UID '${HOST_UID}' because it is not a number"
-        elif [[ ${container_uid} -ne ${HOST_UID} ]]; then
-            result=0
-        fi
-
-        if [[ ! ${HOST_GID} =~ ^[0-9]+$ ]]; then
-            msgbox warning "Ignoring HOST_GID '${HOST_GID}' because it is not a number"
-        elif [[ ${container_gid} -ne ${HOST_GID} ]]; then
-            result=0
-        fi
-
-        return "${result}"
-    }
-
-    change_user_ids() {
-        usermod -ou "${HOST_UID}" user || return 1
-        groupmod -og "${HOST_GID}" user || return 1
-        mkdir -p "/run/user/${HOST_UID}" || return 1
-        chown -R user:user "/run/user/${HOST_UID}" || return 1
-        sed -i "s|/run/user/1000|/run/user/${HOST_UID}|g" /etc/pulse/client.conf || return 1
-    }
-
-    if should_change_user_ids; then
-        msgbox info "Changing user ids to ${HOST_UID}:${HOST_GID}"
-        if change_user_ids; then
-            msgbox ok "Changed user ids"
-        else
-            msgbox error "Failed to change user ids"
-            return 1
-        fi
-    else
-        msgbox info "Nothing to do, user ids are already ${HOST_UID}:${HOST_GID}"
-    fi
-}
-
 #########################################
 ##### Launch update or start script #####
 
+msgbox info "Starting or installing Zwift"
 msgbox debug "Entrypoint script invoked with arguments: ${*:-none}"
 
 actual_user="$(whoami)"
 actual_uid="$(id -u "${actual_user}")"
 actual_gid="$(id -g "${actual_user}")"
 msgbox debug "Running as ${actual_user} (uid=${actual_uid}, gid=${actual_gid})"
-
-if [[ ${1:-} == "--remap-user" ]]; then
-    msgbox info "Remapping container user to host user"
-    if remap_user; then
-        msgbox ok "Remapped container user to host user"
-        exit 0
-    else
-        msgbox error "Failed to remap container user to host user"
-        exit 1
-    fi
-fi
-
-msgbox info "Starting or installing Zwift"
 
 if is_user_root; then
     msgbox error "Cannot run or install Zwift as root!"

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -45,34 +45,25 @@ msgbox() {
     esac
 }
 
-###########################
-##### Configure Zwift #####
-
-# If Wayland Experimental need to blank DISPLAY here to enable Wayland.
-# NOTE: DISPLAY must be unset here before run_zwift to work
-#       Registry entries are set in the container install or won't work.
-if [[ ${WINE_EXPERIMENTAL_WAYLAND} -eq 1 ]]; then
-    unset DISPLAY
-fi
-
-############################################
-##### Clean install, update or launch? #####
-
-msgbox debug "Entrypoint script invoked with arguments: ${*:-none}"
-
-declare -a startup_cmd
-
-if [[ ${1:-} == "--install" ]] || [[ ${1:-} == "--update" ]]; then
-    startup_cmd=(/bin/update_zwift.sh "${1:-}")
-else
-    startup_cmd=(/bin/run_zwift.sh)
-fi
+is_user_root() {
+    [[ ${EUID} -eq 0 ]]
+}
 
 #################################################
 ##### Add container user to host user group #####
 
-if [[ ${CONTAINER_TOOL} == "docker" ]]; then
+remap_user() {
     # docker does not support remapping container user to host user out of the box
+
+    if ! is_user_root; then
+        msgbox error "Must be root to remap user"
+        return 1
+    fi
+
+    if [[ ${CONTAINER_TOOL} != "docker" ]]; then
+        msgbox error "User should only be remapped when using docker"
+        return 1
+    fi
 
     container_uid="$(id -u user)"
     container_gid="$(id -g user)"
@@ -99,11 +90,11 @@ if [[ ${CONTAINER_TOOL} == "docker" ]]; then
     }
 
     change_user_ids() {
-        sudo usermod -ou "${HOST_UID}" user || return 1
-        sudo groupmod -og "${HOST_GID}" user || return 1
-        sudo mkdir -p "/run/user/${HOST_UID}" || return 1
-        sudo chown -R user:user "/run/user/${HOST_UID}" || return 1
-        sudo sed -i "s|/run/user/1000|/run/user/${container_uid}|g" /etc/pulse/client.conf || return 1
+        usermod -ou "${HOST_UID}" user || return 1
+        groupmod -og "${HOST_GID}" user || return 1
+        mkdir -p "/run/user/${HOST_UID}" || return 1
+        chown -R user:user "/run/user/${HOST_UID}" || return 1
+        sed -i "s|/run/user/1000|/run/user/${HOST_UID}|g" /etc/pulse/client.conf || return 1
     }
 
     if should_change_user_ids; then
@@ -112,17 +103,55 @@ if [[ ${CONTAINER_TOOL} == "docker" ]]; then
             msgbox ok "Changed user ids"
         else
             msgbox error "Failed to change user ids"
-            exit 1
+            return 1
         fi
+    else
+        msgbox info "Nothing to do, user ids are already ${HOST_UID}:${HOST_GID}"
     fi
-fi
+}
 
 #########################################
 ##### Launch update or start script #####
+
+msgbox debug "Entrypoint script invoked with arguments: ${*:-none}"
 
 actual_user="$(whoami)"
 actual_uid="$(id -u "${actual_user}")"
 actual_gid="$(id -g "${actual_user}")"
 msgbox debug "Running as ${actual_user} (uid=${actual_uid}, gid=${actual_gid})"
+
+if [[ ${1:-} == "--remap-user" ]]; then
+    msgbox info "Remapping container user to host user"
+    if remap_user; then
+        msgbox ok "Remapped container user to host user"
+        exit 0
+    else
+        msgbox error "Failed to remap container user to host user"
+        exit 1
+    fi
+fi
+
+msgbox info "Starting or installing Zwift"
+
+if is_user_root; then
+    msgbox error "Cannot run or install Zwift as root!"
+    exit 1
+fi
+
+# If Wayland Experimental need to blank DISPLAY here to enable Wayland.
+# NOTE: DISPLAY must be unset here before run_zwift to work
+#       Registry entries are set in the container install or won't work.
+if [[ ${WINE_EXPERIMENTAL_WAYLAND} -eq 1 ]]; then
+    msgbox info "Using Wayland, unsetting DISPLAY environment variable"
+    unset DISPLAY
+fi
+
+declare -a startup_cmd
+
+if [[ ${1:-} == "--install" ]] || [[ ${1:-} == "--update" ]]; then
+    startup_cmd=(/bin/update_zwift.sh "${1:-}")
+else
+    startup_cmd=(/bin/run_zwift.sh)
+fi
 
 "${startup_cmd[@]}"

--- a/src/run_zwift.sh
+++ b/src/run_zwift.sh
@@ -66,6 +66,16 @@ if [[ ! -d ${ZWIFT_HOME} ]] || ! cd "${ZWIFT_HOME}"; then
     exit 1
 fi
 
+if [[ ! -d ${ZWIFT_DOCS} ]] || [[ ! -O ${ZWIFT_DOCS} ]] || [[ ! -G ${ZWIFT_DOCS} ]]; then
+    # shellcheck disable=SC2016 # using a command as literal string on the next line
+    expected_owner='$(id -u $USER):$(id -g $USER)'
+    [[ ${CONTAINER_TOOL} == "podman" ]] && expected_owner="1000:1000"
+    msgbox error "Directory ${ZWIFT_DOCS} does not exist or is not accessible."
+    msgbox error "You can try to fix its permissions by running:"
+    msgbox error "  ${CONTAINER_TOOL} run --rm --user root -it -v zwift-\$USER:/zwift-docs --entrypoint bash netbrain/zwift:latest -c \"chown -R ${expected_owner} /zwift-docs\""
+    exit 1
+fi
+
 if [[ -n ${ZWIFT_OVERRIDE_RESOLUTION} ]]; then
     if [[ -f ${ZWIFT_PREFS} ]]; then
         msgbox info "Setting zwift resolution to ${ZWIFT_OVERRIDE_RESOLUTION}."

--- a/src/run_zwift.sh
+++ b/src/run_zwift.sh
@@ -111,6 +111,16 @@ fi
 ##############################################
 ##### Sync Zwift volume to Zwift AppData #####
 
+if [[ -n ${ZWIFT_VOLUME} ]] && { [[ ! -d ${ZWIFT_VOLUME} ]] || [[ ! -O ${ZWIFT_VOLUME} ]] || [[ ! -G ${ZWIFT_VOLUME} ]]; }; then
+    # shellcheck disable=SC2016 # using a command as literal string on the next line
+    expected_owner='$(id -u $USER):$(id -g $USER)'
+    [[ ${CONTAINER_TOOL} == "podman" ]] && expected_owner="1000:1000"
+    msgbox error "Directory ${ZWIFT_VOLUME} does not exist or is not accessible."
+    msgbox error "You can try to fix its permissions by running:"
+    msgbox error "  ${CONTAINER_TOOL} run --rm --user root -it -v zwift-\$USER:/tmp/zwift-data --entrypoint bash netbrain/zwift:latest -c \"chown -R ${expected_owner} /tmp/zwift-data\""
+    exit 1
+fi
+
 if [[ -n ${ZWIFT_VOLUME} ]] && [[ ${ZWIFT_VOLUME} != "${ZWIFT_DATA_DIR}" ]]; then
     msgbox info "Synchronizing Zwift settings"
     if rsync -qa "${ZWIFT_VOLUME}/" "${ZWIFT_DATA_DIR}/"; then

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -364,13 +364,13 @@ else
         local tag_name="${1:?}"
 
         local latest_image_digest=""
-        if ! latest_image_digest="$(${CONTAINER_TOOL} inspect "${IMAGE}:${VERSION}" --format '{{.Digest}}')"; then
-            msgbox error "Failed to get ${IMAGE}:${VERSION} image digest"
-            exit 1
+        if ! latest_image_digest="$(${CONTAINER_TOOL} inspect "${IMAGE}:${VERSION}" --format '{{index .RepoDigests 0}}' 2> /dev/null)"; then
+            msgbox warning "Failed to get ${IMAGE}:${VERSION} image digest"
+            return 0
         fi
 
         local current_image_digest=""
-        if ! current_image_digest="$(${CONTAINER_TOOL} inspect "${tag_name}" --format '{{index .Config.Labels "org.opencontainers.image.base.digest"}}')"; then
+        if ! current_image_digest="$(${CONTAINER_TOOL} inspect "${tag_name}" --format '{{index .Config.Labels "org.opencontainers.image.base.digest"}}' 2> /dev/null))"; then
             msgbox info "Failed to get ${tag_name} base image digest, may not exist yet"
             return 0
         fi
@@ -389,9 +389,9 @@ else
         fi
 
         local image_digest=""
-        if ! image_digest="$(${CONTAINER_TOOL} inspect "${IMAGE}:${VERSION}" --format '{{.Digest}}')"; then
-            msgbox error "Failed to get ${IMAGE}:${VERSION} image digest"
-            return 1
+        if ! image_digest="$(${CONTAINER_TOOL} inspect "${IMAGE}:${VERSION}" --format '{{index .RepoDigests 0}}' 2> /dev/null)"; then
+            msgbox warning "Failed to get ${IMAGE}:${VERSION} image digest"
+            image_digest="${IMAGE}:${VERSION}"
         fi
 
         {

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -422,22 +422,20 @@ else
         fi
     }
 
+    msgbox info "Remapping container user to host user"
     container_uid="${host_uid}"
     container_gid="${host_gid}"
-    if [[ ${host_uid} -ne 1000 ]] || [[ ${host_gid} -ne 1000 ]]; then
-        msgbox info "Remapping container user to host user"
-        container_image="netbrain/zwift"
-        container_image_version="remapped_user_${container_uid}_${container_gid}"
-        if remap_build_required "${container_image}:${container_image_version}"; then
-            if remap_dockerfile="$(create_remap_dockerfile "${container_uid}" "${container_gid}")" && build_remap_dockerfile "${container_image}:${container_image_version}" "${remap_dockerfile}"; then
-                msgbox ok "Remapped container user to host user"
-            else
-                msgbox error "Failed to remap container user to host user"
-                exit 1
-            fi
+    container_image="netbrain/zwift"
+    container_image_version="remapped_user_${container_uid}_${container_gid}"
+    if remap_build_required "${container_image}:${container_image_version}"; then
+        if remap_dockerfile="$(create_remap_dockerfile "${container_uid}" "${container_gid}")" && build_remap_dockerfile "${container_image}:${container_image_version}" "${remap_dockerfile}"; then
+            msgbox ok "Remapped container user to host user"
         else
-            msgbox ok "${container_image}:${container_image_version} is up to date"
+            msgbox error "Failed to remap container user to host user"
+            exit 1
         fi
+    else
+        msgbox ok "${container_image}:${container_image_version} is up to date"
     fi
 fi
 

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -175,10 +175,17 @@ readonly ZWIFT_FG="${ZWIFT_FG:-0}"
 readonly ZWIFT_NO_GAMEMODE="${ZWIFT_NO_GAMEMODE:-0}"
 readonly WINE_EXPERIMENTAL_WAYLAND="${WINE_EXPERIMENTAL_WAYLAND:-0}"
 readonly NETWORKING="${NETWORKING:-bridge}"
-readonly ZWIFT_UID="${ZWIFT_UID:-${UID}}"
-readonly ZWIFT_GID="${ZWIFT_GID:-$(id -g)}"
 readonly VGA_DEVICE_FLAG="${VGA_DEVICE_FLAG:-}"
 readonly PRIVILEGED_CONTAINER="${PRIVILEGED_CONTAINER:-0}"
+
+# No longer supported configuration environment variables
+readonly ZWIFT_UID="${ZWIFT_UID:-}"
+readonly ZWIFT_GID="${ZWIFT_GID:-}"
+if [[ -n ${ZWIFT_UID} ]] || [[ -n ${ZWIFT_GID} ]]; then
+    msgbox error "ZWIFT_UID and ZWIFT_GID options are no longer supported"
+    msgbox error "  To start Zwift as a different user, use: sudo -i username zwift"
+    exit 1
+fi
 
 # Initialize CONTAINER_TOOL: Use podman if available
 msgbox info "Looking for container tool"
@@ -206,8 +213,8 @@ declare -a parameters_to_print
 parameters_to_print=(
     DEBUG VERBOSITY CONTAINER_TOOL IMAGE VERSION SCRIPT_VERSION DONT_CHECK DONT_PULL DONT_CLEAN DRYRUN INTERACTIVE
     CONTAINER_EXTRA_ARGS ZWIFT_USERNAME ZWIFT_PASSWORD ZWIFT_WORKOUT_DIR ZWIFT_ACTIVITY_DIR ZWIFT_LOG_DIR ZWIFT_SCREENSHOTS_DIR
-    ZWIFT_OVERRIDE_GRAPHICS ZWIFT_OVERRIDE_RESOLUTION ZWIFT_FG ZWIFT_NO_GAMEMODE WINE_EXPERIMENTAL_WAYLAND NETWORKING ZWIFT_UID
-    ZWIFT_GID VGA_DEVICE_FLAG PRIVILEGED_CONTAINER DBUS_SESSION_BUS_ADDRESS DISPLAY WAYLAND_DISPLAY XAUTHORITY XDG_RUNTIME_DIR
+    ZWIFT_OVERRIDE_GRAPHICS ZWIFT_OVERRIDE_RESOLUTION ZWIFT_FG ZWIFT_NO_GAMEMODE WINE_EXPERIMENTAL_WAYLAND NETWORKING
+    VGA_DEVICE_FLAG PRIVILEGED_CONTAINER DBUS_SESSION_BUS_ADDRESS DISPLAY WAYLAND_DISPLAY XAUTHORITY XDG_RUNTIME_DIR
 )
 for parameter_to_print in "${parameters_to_print[@]}"; do
     parameter_print_value="$(declare -p "${parameter_to_print}")"
@@ -342,26 +349,24 @@ container_args=()
 declare -a entrypoint_args
 entrypoint_args=()
 
+# Initialize user ids
+host_uid="${UID}"
+host_gid="$(id -g)"
 if [[ ${CONTAINER_TOOL} == "podman" ]]; then
-    # Podman has to use container id 1000
-    # Local user is mapped to the container id
-    local_uid="${ZWIFT_UID}"
     container_uid=1000
-    container_gid=1000
-    container_args+=(--userns "keep-id:uid=${container_uid},gid=${container_gid}")
+    container_args+=(--userns="keep-id:uid=1000,gid=1000")
 else
-    # Docker will run as the id's provided.
-    local_uid="${UID}"
-    container_uid="${ZWIFT_UID}"
-    container_gid="${ZWIFT_GID}"
+    container_uid="${host_uid}"
+    container_env_vars+=(
+        HOST_UID="${host_uid}"
+        HOST_GID="${host_gid}"
+    )
 fi
 
 # Define base container environment variables
 container_env_vars+=(
     DEBUG="${DEBUG}"
     VERBOSITY="${VERBOSITY}"
-    ZWIFT_UID="${container_uid}"
-    ZWIFT_GID="${container_gid}"
     CONTAINER_TOOL="${CONTAINER_TOOL}"
 )
 
@@ -587,18 +592,13 @@ fi
 if [[ ${window_manager} == "Wayland" ]]; then
     msgbox info "Using Wayland window manager"
 
-    if [[ ${ZWIFT_UID} -ne ${UID} ]]; then
-        msgbox error "Wayland does not support ZWIFT_UID different to your id of ${UID}"
-        exit 1
-    fi
-
     if [[ -n ${XDG_RUNTIME_DIR} ]] && [[ -n ${WAYLAND_DISPLAY} ]]; then
         container_env_vars+=(
-            XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR//${local_uid}/${container_uid}}"
+            XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR//${host_uid}/${container_uid}}"
             WAYLAND_DISPLAY="${WAYLAND_DISPLAY}"
             WINE_EXPERIMENTAL_WAYLAND="1"
         )
-        container_args+=(-v "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}:${XDG_RUNTIME_DIR//${local_uid}/${container_uid}}/${WAYLAND_DISPLAY}")
+        container_args+=(-v "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}:${XDG_RUNTIME_DIR//${host_uid}/${container_uid}}/${WAYLAND_DISPLAY}")
     else
         msgbox error "Required environment variables XDG_RUNTIME_DIR and/or WAYLAND_DISPLAY are not set"
         msgbox error "Falling back to XWayland" 5
@@ -625,8 +625,8 @@ if [[ ${window_manager} == "XWayland" ]] || [[ ${window_manager} == "XOrg" ]]; t
     fi
 
     if [[ -n ${XAUTHORITY} ]]; then
-        container_env_vars+=(XAUTHORITY="${XAUTHORITY//${local_uid}/${container_uid}}")
-        container_args+=(-v "${XAUTHORITY}:${XAUTHORITY//${local_uid}/${container_uid}}")
+        container_env_vars+=(XAUTHORITY="${XAUTHORITY//${host_uid}/${container_uid}}")
+        container_args+=(-v "${XAUTHORITY}:${XAUTHORITY//${host_uid}/${container_uid}}")
     else
         msgbox info "XAUTHORITY environment variable not set, container access to X11 needs to be granted with xhost"
         xhost_access_required=1
@@ -641,17 +641,17 @@ if [[ -n ${DBUS_SESSION_BUS_ADDRESS} ]]; then
     [[ ${DBUS_SESSION_BUS_ADDRESS} =~ ^unix:path=([^,]+) ]]
     dbus_unix_socket=${BASH_REMATCH[1]}
     if [[ -n ${dbus_unix_socket} ]]; then
-        container_env_vars+=(DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS//${local_uid}/${container_uid}}")
-        container_args+=(-v "${dbus_unix_socket}:${dbus_unix_socket//${local_uid}/${container_uid}}")
+        container_env_vars+=(DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS//${host_uid}/${container_uid}}")
+        container_args+=(-v "${dbus_unix_socket}:${dbus_unix_socket//${host_uid}/${container_uid}}")
     fi
 fi
 
 # Configure sound driver
 container_env_vars+=(PULSE_SERVER="/run/user/${container_uid}/pulse/native")
-if [[ -d "/run/user/${local_uid}/pulse" ]]; then
-    container_args+=(-v "/run/user/${local_uid}/pulse:/run/user/${container_uid}/pulse")
+if [[ -d "/run/user/${host_uid}/pulse" ]]; then
+    container_args+=(-v "/run/user/${host_uid}/pulse:/run/user/${container_uid}/pulse")
 else
-    msgbox warning "PulseAudio socket /run/user/${local_uid}/pulse not found — audio may not work (PipeWire-only system?)"
+    msgbox warning "PulseAudio socket /run/user/${host_uid}/pulse not found — audio may not work (PipeWire-only system?)"
 fi
 
 # Check for proprietary nvidia driver and set correct device to use (respects existing VGA_DEVICE_FLAG)

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -473,8 +473,8 @@ else
     container_uid="${host_uid}"
     container_gid="${host_gid}"
 
-    container_image="netbrain/zwift"
-    container_image_version="remapped_user_${container_uid}_${container_gid}"
+    container_image="${IMAGE#docker.io/}"
+    container_image_version="uid_${container_uid}_gid_${container_gid}"
 
     msgbox info "Remapping container user to host user"
     if remap_build_required "${container_image}:${container_image_version}"; then

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -360,13 +360,37 @@ if [[ ${CONTAINER_TOOL} == "podman" ]]; then
     container_gid=1000
     container_args+=(--userns="keep-id:uid=${container_uid},gid=${container_gid}")
 else
+    remap_build_required() {
+        local tag_name="${1:?}"
+
+        local latest_image_digest=""
+        if ! latest_image_digest="$(${CONTAINER_TOOL} inspect "${IMAGE}:${VERSION}" --format '{{.Digest}}')"; then
+            msgbox error "Failed to get ${IMAGE}:${VERSION} image digest"
+            exit 1
+        fi
+
+        local current_image_digest=""
+        if ! current_image_digest="$(${CONTAINER_TOOL} inspect "${tag_name}" --format '{{index .Config.Labels "org.opencontainers.image.base.digest"}}')"; then
+            msgbox info "Failed to get ${tag_name} base image digest, may not exist yet"
+            return 0
+        fi
+
+        [[ ${current_image_digest} != "${latest_image_digest}" ]]
+    }
+
     create_remap_dockerfile() {
         local user_uid="${1:?}"
         local user_gid="${2:?}"
-        local tmp_file=""
 
+        local tmp_file=""
         if ! tmp_file="$(mktemp -q /tmp/zwift-remap-user.dockerfile.XXXXXXXXXX)"; then
             msgbox error "Failed to create dockerfile for remapping user"
+            return 1
+        fi
+
+        local image_digest=""
+        if ! image_digest="$(${CONTAINER_TOOL} inspect "${IMAGE}:${VERSION}" --format '{{.Digest}}')"; then
+            msgbox error "Failed to get ${IMAGE}:${VERSION} image digest"
             return 1
         fi
 
@@ -380,6 +404,7 @@ else
             echo " && sed -i \"s|/run/user/1000|/run/user/${user_uid}|g\" /etc/pulse/client.conf"
             echo "USER user"
             echo 'ENTRYPOINT ["entrypoint"]'
+            echo "LABEL org.opencontainers.image.base.digest=\"${image_digest}\""
         } > "${tmp_file}"
 
         echo "${tmp_file}"
@@ -403,11 +428,15 @@ else
         msgbox info "Remapping container user to host user"
         container_image="netbrain/zwift"
         container_image_version="remapped_user_${container_uid}_${container_gid}"
-        if remap_dockerfile="$(create_remap_dockerfile "${container_uid}" "${container_gid}")" && build_remap_dockerfile "${container_image}:${container_image_version}" "${remap_dockerfile}"; then
-            msgbox ok "Remapped container user to host user"
+        if remap_build_required "${container_image}:${container_image_version}"; then
+            if remap_dockerfile="$(create_remap_dockerfile "${container_uid}" "${container_gid}")" && build_remap_dockerfile "${container_image}:${container_image_version}" "${remap_dockerfile}"; then
+                msgbox ok "Remapped container user to host user"
+            else
+                msgbox error "Failed to remap container user to host user"
+                exit 1
+            fi
         else
-            msgbox error "Failed to remap container user to host user"
-            exit 1
+            msgbox ok "${container_image}:${container_image_version} is up to date"
         fi
     fi
 fi

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -504,7 +504,7 @@ fi
 volume_remap_required() {
     ${CONTAINER_TOOL} run --rm \
         -v "zwift-${USER}:/zwift-docs" \
-        -it --entrypoint bash \
+        --entrypoint bash \
         "${container_image}:${container_image_version}" \
         -c "[[ ! -O /zwift-docs ]] || [[ ! -G /zwift-docs ]]"
 }
@@ -513,7 +513,7 @@ remap_volume() {
     ${CONTAINER_TOOL} run --rm \
         --user root \
         -v "zwift-${USER}:/zwift-docs" \
-        -it --entrypoint bash \
+        --entrypoint bash \
         "${container_image}:${container_image_version}" \
         -c "chown -R \"${container_uid}:${container_gid}\" /zwift-docs"
 }

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -488,6 +488,48 @@ else
     fi
 fi
 
+# Create the volume for the zwift documents directory if it does not already exist
+if ! ${CONTAINER_TOOL} volume inspect "zwift-${USER}" > /dev/null 2>&1; then
+    msgbox info "Creating ${CONTAINER_TOOL} volume zwift-${USER}"
+    if ${CONTAINER_TOOL} volume create "zwift-${USER}" > /dev/null 2>&1; then
+        msgbox ok "Created volume zwift-${USER}"
+    else
+        msgbox error "Failed to create volume zwift-${USER}"
+        exit 1
+    fi
+fi
+
+volume_remap_required() {
+    ${CONTAINER_TOOL} run --rm \
+        -v "zwift-${USER}:/zwift-docs" \
+        -it --entrypoint bash \
+        "${container_image}:${container_image_version}" \
+        -c "[[ ! -O /zwift-docs ]] || [[ ! -G /zwift-docs ]]"
+}
+
+remap_volume() {
+    ${CONTAINER_TOOL} run --rm \
+        --user root \
+        -v "zwift-${USER}:/zwift-docs" \
+        -it --entrypoint bash \
+        "${container_image}:${container_image_version}" \
+        -c "chown -R \"${container_uid}:${container_gid}\" /zwift-docs"
+}
+
+# Docker: Remap volume to container user
+# Necessary in two cases:
+# - Volume was just created, owner will be root, remap required
+# - End user changed user uid/gid, remap required
+if [[ ${CONTAINER_TOOL} != "podman" ]] && volume_remap_required; then
+    msgbox info "Updating owner of volume zwift-${USER}"
+    if remap_volume; then
+        msgbox ok "Updated zwift-${USER} volume owner to ${container_uid}:${container_gid}"
+    else
+        msgbox error "Failed to update zwift-${USER} volume owner to ${container_uid}:${container_gid}"
+        exit 1
+    fi
+fi
+
 ##############################################
 ##### User defined environment variables #####
 
@@ -790,26 +832,6 @@ if [[ ${DRYRUN} -eq 1 ]]; then
 else
     msgbox debug "Starting ${CONTAINER_TOOL} container with the following arguments:"
     print_container_command debug
-fi
-
-# Create the volume for the zwift documents directory if it does not already exist
-if ! ${CONTAINER_TOOL} volume inspect "zwift-${USER}" > /dev/null 2>&1; then
-    msgbox info "Creating ${CONTAINER_TOOL} volume zwift-${USER}"
-    if ${CONTAINER_TOOL} volume create "zwift-${USER}" > /dev/null 2>&1; then
-        msgbox ok "Created volume zwift-${USER}"
-    else
-        msgbox error "Failed to create volume zwift-${USER}"
-        exit 1
-    fi
-    if [[ ${CONTAINER_TOOL} != "podman" ]]; then
-        msgbox info "Updating owner of volume zwift-${USER}"
-        if ${CONTAINER_TOOL} run --rm --user root -it -v "zwift-${USER}:/zwift-docs" --entrypoint bash "${container_image}:${container_image_version}" -c "chown -R \"${container_uid}:${container_gid}\" /zwift-docs"; then
-            msgbox ok "Updated zwift-${USER} volume owner to ${container_uid}:${container_gid}"
-        else
-            msgbox error "Failed to update zwift-${USER} volume owner to ${container_uid}:${container_gid}"
-            exit 1
-        fi
-    fi
 fi
 
 # Only write environment variables to file when needed

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -430,11 +430,11 @@ create_remap_dockerfile() {
 
     echo "FROM ${IMAGE}:${VERSION}"
     echo "USER root"
-    echo "RUN usermod -ou ${user_uid} user \\"
+    echo "RUN sed -i \"s|/run/user/\$(id -u user)|/run/user/${user_uid}|g\" /etc/pulse/client.conf \\"
+    echo " && usermod -ou ${user_uid} user \\"
     echo " && groupmod -og ${user_gid} user \\"
     echo " && mkdir -p /run/user/${user_uid} \\"
-    echo " && chown -R user:user /run/user/${user_uid} \\"
-    echo " && sed -i \"s|/run/user/1000|/run/user/${user_uid}|g\" /etc/pulse/client.conf"
+    echo " && chown -R user:user /run/user/${user_uid}"
     echo "USER user"
     echo 'ENTRYPOINT ["entrypoint"]'
     echo "LABEL org.opencontainers.image.base.digest=\"${image_digest}\""

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -384,34 +384,34 @@ done
 ##### Remap container user to host user #####
 
 image_repo_digest() {
-    # Local images do not have a remote repository, will return 1
+    # Local images do not have a remote repository, will return non-zero
 
     local tag_name="${1:?}"
 
-    local repo_digest
-    repo_digest="$(${CONTAINER_TOOL} inspect "${tag_name}" --format '{{index .RepoDigests 0}}' 2> /dev/null)" || return 1
-    echo "${repo_digest}"
+    ${CONTAINER_TOOL} inspect "${tag_name}" --format '{{index .RepoDigests 0}}' 2> /dev/null
 }
 
 image_digest_label() {
     local tag_name="${1:?}"
 
-    local digest_label
-    digest_label="$(${CONTAINER_TOOL} inspect "${tag_name}" --format '{{index .Config.Labels "org.opencontainers.image.base.digest"}}' 2> /dev/null))" || return 1
-    echo "${digest_label}"
+    ${CONTAINER_TOOL} inspect "${tag_name}" --format '{{index .Config.Labels "org.opencontainers.image.base.digest"}}' 2> /dev/null
 }
 
 remap_build_required() {
     local tag_name="${1:?}"
 
     local latest_image_digest
-    if ! latest_image_digest="$(image_repo_digest "${IMAGE}:${VERSION}")"; then
+    if latest_image_digest="$(image_repo_digest "${IMAGE}:${VERSION}")"; then
+        msgbox debug "Latest image digest is ${latest_image_digest}"
+    else
         msgbox info "Failed to get ${IMAGE}:${VERSION} image repository digest, assuming rebuild is required"
         return 0
     fi
 
     local current_image_digest
-    if ! current_image_digest="$(image_digest_label "${tag_name}")"; then
+    if current_image_digest="$(image_digest_label "${tag_name}")"; then
+        msgbox debug "Base image digest is ${current_image_digest}"
+    else
         msgbox info "Failed to get ${tag_name} base image digest, may not exist yet, assuming rebuild is required"
         return 0
     fi
@@ -424,7 +424,9 @@ create_remap_dockerfile() {
     local user_gid="${2:?}"
 
     local image_digest
-    image_digest="$(image_repo_digest "${IMAGE}:${VERSION}" || echo "Unknown")"
+    if ! image_digest="$(image_repo_digest "${IMAGE}:${VERSION}")"; then
+        image_digest="Unknown"
+    fi
 
     echo "FROM ${IMAGE}:${VERSION}"
     echo "USER root"

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -357,10 +357,53 @@ if [[ ${CONTAINER_TOOL} == "podman" ]]; then
     container_args+=(--userns="keep-id:uid=1000,gid=1000")
 else
     container_uid="${host_uid}"
-    container_env_vars+=(
-        HOST_UID="${host_uid}"
-        HOST_GID="${host_gid}"
-    )
+    tmp_dockerfile=""
+
+    cleanup_remap_container() {
+        msgbox info "Removing temporary container zwift-remap-user"
+        ${CONTAINER_TOOL} rm zwift-remap-user || true
+
+        msgbox info "Removing temporary image zwift-remap-user-image"
+        ${CONTAINER_TOOL} image rm zwift-remap-user-image || true
+
+        msgbox info "Removing temporary dockerfile"
+        [[ -n ${tmp_dockerfile} ]] && [[ -f ${tmp_dockerfile} ]] && rm -f -- "${tmp_dockerfile}" || true
+    }
+
+    if ! tmp_dockerfile="$(mktemp -q /tmp/zwift-remap-user.dockerfile.XXXXXXXXXX)" || ! echo -e "FROM ${IMAGE}:${VERSION}\nUSER root\n ENTRYPOINT [\"entrypoint\"]" > "${tmp_dockerfile}"; then
+        msgbox error "Failed to create temporary dockerfile"
+        cleanup_remap_container
+        exit 1
+    fi
+
+    msgbox info "Creating image to remap user"
+    if ${CONTAINER_TOOL} build -t zwift-remap-user-image -f "${tmp_dockerfile}" .; then
+        msgbox ok "Created image to remap user"
+    else
+        msgbox error "Failed to create image to remap user"
+        cleanup_remap_container
+        exit 1
+    fi
+
+    msgbox info "Remapping container user to host user"
+    if ${CONTAINER_TOOL} run --name zwift-remap-user -e CONTAINER_TOOL="${CONTAINER_TOOL}" -e DEBUG="${DEBUG}" -e VERBOSITY="${VERBOSITY}" -e HOST_UID="${host_uid}" -e HOST_GID="${host_gid}" zwift-remap-user-image --remap-user; then
+        msgbox ok "Remapped container user to host user"
+    else
+        msgbox error "Failed to remap container user to host user"
+        cleanup_remap_container
+        exit 1
+    fi
+
+    msgbox info "Persisting container with remapped user"
+    if ${CONTAINER_TOOL} commit --change="USER user" --change='CMD [""]' -m "Remapped user to ${host_uid}:${host_gid}" zwift-remap-user "${IMAGE}:${VERSION}"; then
+        msgbox ok "Persisted container with remapped user"
+    else
+        msgbox error "Failed to persist container with remapped user"
+        cleanup_remap_container
+        exit 1
+    fi
+
+    cleanup_remap_container
 fi
 
 # Define base container environment variables

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -423,36 +423,35 @@ create_remap_dockerfile() {
     local user_uid="${1:?}"
     local user_gid="${2:?}"
 
-    local tmp_file
-    if ! tmp_file="$(mktemp -q /tmp/zwift-remap-user.dockerfile.XXXXXXXXXX)"; then
-        msgbox error "Failed to create dockerfile for remapping user"
-        return 1
-    fi
-
     local image_digest
     image_digest="$(image_repo_digest "${IMAGE}:${VERSION}" || echo "Unknown")"
 
-    {
-        echo "FROM ${IMAGE}:${VERSION}"
-        echo "USER root"
-        echo "RUN usermod -ou ${user_uid} user \\"
-        echo " && groupmod -og ${user_gid} user \\"
-        echo " && mkdir -p /run/user/${user_uid} \\"
-        echo " && chown -R user:user /run/user/${user_uid} \\"
-        echo " && sed -i \"s|/run/user/1000|/run/user/${user_uid}|g\" /etc/pulse/client.conf"
-        echo "USER user"
-        echo 'ENTRYPOINT ["entrypoint"]'
-        echo "LABEL org.opencontainers.image.base.digest=\"${image_digest}\""
-    } > "${tmp_file}"
-
-    echo "${tmp_file}"
+    echo "FROM ${IMAGE}:${VERSION}"
+    echo "USER root"
+    echo "RUN usermod -ou ${user_uid} user \\"
+    echo " && groupmod -og ${user_gid} user \\"
+    echo " && mkdir -p /run/user/${user_uid} \\"
+    echo " && chown -R user:user /run/user/${user_uid} \\"
+    echo " && sed -i \"s|/run/user/1000|/run/user/${user_uid}|g\" /etc/pulse/client.conf"
+    echo "USER user"
+    echo 'ENTRYPOINT ["entrypoint"]'
+    echo "LABEL org.opencontainers.image.base.digest=\"${image_digest}\""
 }
 
 build_remap_dockerfile() {
     local tag_name="${1:?}"
     local dockerfile="${2:?}"
 
-    if ${CONTAINER_TOOL} build -t "${tag_name}" -f "${dockerfile}" .; then
+    msgbox info "Building container image with remapped user"
+
+    msgbox debug "Using dockerfile:"
+    local dockerfile_lines line
+    readarray -t dockerfile_lines <<< "${dockerfile}"
+    for line in "${dockerfile_lines[@]}"; do
+        msgbox debug "  ${line/\\/\\\\}"
+    done
+
+    if ${CONTAINER_TOOL} build -t "${tag_name}" - <<< "${dockerfile}"; then
         msgbox info "Created ${CONTAINER_TOOL} image ${tag_name}"
     else
         msgbox error "Failed to create ${CONTAINER_TOOL} image ${tag_name}"
@@ -477,7 +476,8 @@ else
 
     msgbox info "Remapping container user to host user"
     if remap_build_required "${container_image}:${container_image_version}"; then
-        if remap_dockerfile="$(create_remap_dockerfile "${container_uid}" "${container_gid}")" && build_remap_dockerfile "${container_image}:${container_image_version}" "${remap_dockerfile}"; then
+        remap_dockerfile="$(create_remap_dockerfile "${container_uid}" "${container_gid}")"
+        if build_remap_dockerfile "${container_image}:${container_image_version}" "${remap_dockerfile}"; then
             msgbox ok "Remapped container user to host user"
         else
             msgbox error "Failed to remap container user to host user"

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -383,18 +383,36 @@ done
 #############################################
 ##### Remap container user to host user #####
 
+image_repo_digest() {
+    # Local images do not have a remote repository, will return 1
+
+    local tag_name="${1:?}"
+
+    local repo_digest
+    repo_digest="$(${CONTAINER_TOOL} inspect "${tag_name}" --format '{{index .RepoDigests 0}}' 2> /dev/null)" || return 1
+    echo "${repo_digest}"
+}
+
+image_digest_label() {
+    local tag_name="${1:?}"
+
+    local digest_label
+    digest_label="$(${CONTAINER_TOOL} inspect "${tag_name}" --format '{{index .Config.Labels "org.opencontainers.image.base.digest"}}' 2> /dev/null))" || return 1
+    echo "${digest_label}"
+}
+
 remap_build_required() {
     local tag_name="${1:?}"
 
-    local latest_image_digest=""
-    if ! latest_image_digest="$(${CONTAINER_TOOL} inspect "${IMAGE}:${VERSION}" --format '{{index .RepoDigests 0}}' 2> /dev/null)"; then
-        msgbox warning "Failed to get ${IMAGE}:${VERSION} image digest"
+    local latest_image_digest
+    if ! latest_image_digest="$(image_repo_digest "${IMAGE}:${VERSION}")"; then
+        msgbox info "Failed to get ${IMAGE}:${VERSION} image repository digest, assuming rebuild is required"
         return 0
     fi
 
-    local current_image_digest=""
-    if ! current_image_digest="$(${CONTAINER_TOOL} inspect "${tag_name}" --format '{{index .Config.Labels "org.opencontainers.image.base.digest"}}' 2> /dev/null))"; then
-        msgbox info "Failed to get ${tag_name} base image digest, may not exist yet"
+    local current_image_digest
+    if ! current_image_digest="$(image_digest_label "${tag_name}")"; then
+        msgbox info "Failed to get ${tag_name} base image digest, may not exist yet, assuming rebuild is required"
         return 0
     fi
 
@@ -405,17 +423,14 @@ create_remap_dockerfile() {
     local user_uid="${1:?}"
     local user_gid="${2:?}"
 
-    local tmp_file=""
+    local tmp_file
     if ! tmp_file="$(mktemp -q /tmp/zwift-remap-user.dockerfile.XXXXXXXXXX)"; then
         msgbox error "Failed to create dockerfile for remapping user"
         return 1
     fi
 
-    local image_digest=""
-    if ! image_digest="$(${CONTAINER_TOOL} inspect "${IMAGE}:${VERSION}" --format '{{index .RepoDigests 0}}' 2> /dev/null)"; then
-        msgbox warning "Failed to get ${IMAGE}:${VERSION} image digest"
-        image_digest="${IMAGE}:${VERSION}"
-    fi
+    local image_digest
+    image_digest="$(image_repo_digest "${IMAGE}:${VERSION}" || echo "Unknown")"
 
     {
         echo "FROM ${IMAGE}:${VERSION}"

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -323,6 +323,9 @@ if [[ ${DONT_CLEAN} -ne 1 ]] && [[ ${DONT_PULL} -ne 1 ]]; then
     fi
 fi
 
+container_image="${IMAGE}"
+container_image_version="${VERSION}"
+
 ###############################
 ##### Basic configuration #####
 
@@ -354,56 +357,59 @@ host_uid="${UID}"
 host_gid="$(id -g)"
 if [[ ${CONTAINER_TOOL} == "podman" ]]; then
     container_uid=1000
-    container_args+=(--userns="keep-id:uid=1000,gid=1000")
+    container_gid=1000
+    container_args+=(--userns="keep-id:uid=${container_uid},gid=${container_gid}")
 else
-    container_uid="${host_uid}"
-    tmp_dockerfile=""
+    create_remap_dockerfile() {
+        local user_uid="${1:?}"
+        local user_gid="${2:?}"
+        local tmp_file=""
 
-    cleanup_remap_container() {
-        msgbox info "Removing temporary container zwift-remap-user"
-        ${CONTAINER_TOOL} rm zwift-remap-user || true
+        if ! tmp_file="$(mktemp -q /tmp/zwift-remap-user.dockerfile.XXXXXXXXXX)"; then
+            msgbox error "Failed to create dockerfile for remapping user"
+            return 1
+        fi
 
-        msgbox info "Removing temporary image zwift-remap-user-image"
-        ${CONTAINER_TOOL} image rm zwift-remap-user-image || true
+        {
+            echo "FROM ${IMAGE}:${VERSION}"
+            echo "USER root"
+            echo "RUN usermod -ou ${user_uid} user \\"
+            echo " && groupmod -og ${user_gid} user \\"
+            echo " && mkdir -p /run/user/${user_uid} \\"
+            echo " && chown -R user:user /run/user/${user_uid} \\"
+            echo " && sed -i \"s|/run/user/1000|/run/user/${user_uid}|g\" /etc/pulse/client.conf"
+            echo "USER user"
+            echo 'ENTRYPOINT ["entrypoint"]'
+        } > "${tmp_file}"
 
-        msgbox info "Removing temporary dockerfile"
-        [[ -n ${tmp_dockerfile} ]] && [[ -f ${tmp_dockerfile} ]] && rm -f -- "${tmp_dockerfile}" || true
+        echo "${tmp_file}"
     }
 
-    if ! tmp_dockerfile="$(mktemp -q /tmp/zwift-remap-user.dockerfile.XXXXXXXXXX)" || ! echo -e "FROM ${IMAGE}:${VERSION}\nUSER root\n ENTRYPOINT [\"entrypoint\"]" > "${tmp_dockerfile}"; then
-        msgbox error "Failed to create temporary dockerfile"
-        cleanup_remap_container
-        exit 1
-    fi
+    build_remap_dockerfile() {
+        local tag_name="${1:?}"
+        local dockerfile="${2:?}"
 
-    msgbox info "Creating image to remap user"
-    if ${CONTAINER_TOOL} build -t zwift-remap-user-image -f "${tmp_dockerfile}" .; then
-        msgbox ok "Created image to remap user"
-    else
-        msgbox error "Failed to create image to remap user"
-        cleanup_remap_container
-        exit 1
-    fi
+        if ${CONTAINER_TOOL} build -t "${tag_name}" -f "${dockerfile}" .; then
+            msgbox info "Created ${CONTAINER_TOOL} image ${tag_name}"
+        else
+            msgbox error "Failed to create ${CONTAINER_TOOL} image ${tag_name}"
+            return 1
+        fi
+    }
 
-    msgbox info "Remapping container user to host user"
-    if ${CONTAINER_TOOL} run --name zwift-remap-user -e CONTAINER_TOOL="${CONTAINER_TOOL}" -e DEBUG="${DEBUG}" -e VERBOSITY="${VERBOSITY}" -e HOST_UID="${host_uid}" -e HOST_GID="${host_gid}" zwift-remap-user-image --remap-user; then
-        msgbox ok "Remapped container user to host user"
-    else
-        msgbox error "Failed to remap container user to host user"
-        cleanup_remap_container
-        exit 1
+    container_uid="${host_uid}"
+    container_gid="${host_gid}"
+    if [[ ${host_uid} -ne 1000 ]] || [[ ${host_gid} -ne 1000 ]]; then
+        msgbox info "Remapping container user to host user"
+        container_image="netbrain/zwift"
+        container_image_version="remapped_user_${container_uid}_${container_gid}"
+        if remap_dockerfile="$(create_remap_dockerfile "${container_uid}" "${container_gid}")" && build_remap_dockerfile "${container_image}:${container_image_version}" "${remap_dockerfile}"; then
+            msgbox ok "Remapped container user to host user"
+        else
+            msgbox error "Failed to remap container user to host user"
+            exit 1
+        fi
     fi
-
-    msgbox info "Persisting container with remapped user"
-    if ${CONTAINER_TOOL} commit --change="USER user" --change='CMD [""]' -m "Remapped user to ${host_uid}:${host_gid}" zwift-remap-user "${IMAGE}:${VERSION}"; then
-        msgbox ok "Persisted container with remapped user"
-    else
-        msgbox error "Failed to persist container with remapped user"
-        cleanup_remap_container
-        exit 1
-    fi
-
-    cleanup_remap_container
 fi
 
 # Define base container environment variables
@@ -717,7 +723,7 @@ fi
 ##### Start container #####
 
 declare -a container_command
-container_command=("${CONTAINER_TOOL}" run "${container_args[@]}" "${IMAGE}:${VERSION}" "${entrypoint_args[@]}")
+container_command=("${CONTAINER_TOOL}" run "${container_args[@]}" "${container_image}:${container_image_version}" "${entrypoint_args[@]}")
 
 # Print the exact command that would be executed
 

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -792,15 +792,23 @@ else
     print_container_command debug
 fi
 
-# Create a volume if not already exists, this is done now as
-# if left to the run command the directory can get the wrong permissions
-if [[ ${CONTAINER_TOOL} == "podman" ]] && ! ${CONTAINER_TOOL} volume inspect "zwift-${USER}" > /dev/null 2>&1; then
+# Create the volume for the zwift documents directory if it does not already exist
+if ! ${CONTAINER_TOOL} volume inspect "zwift-${USER}" > /dev/null 2>&1; then
     msgbox info "Creating ${CONTAINER_TOOL} volume zwift-${USER}"
-    if ${CONTAINER_TOOL} volume create "zwift-${USER}"; then
+    if ${CONTAINER_TOOL} volume create "zwift-${USER}" > /dev/null 2>&1; then
         msgbox ok "Created volume zwift-${USER}"
     else
         msgbox error "Failed to create volume zwift-${USER}"
         exit 1
+    fi
+    if [[ ${CONTAINER_TOOL} != "podman" ]]; then
+        msgbox info "Updating owner of volume zwift-${USER}"
+        if ${CONTAINER_TOOL} run --rm --user root -it -v "zwift-${USER}:/zwift-docs" --entrypoint bash "${container_image}:${container_image_version}" -c "chown -R \"${container_uid}:${container_gid}\" /zwift-docs"; then
+            msgbox ok "Updated zwift-${USER} volume owner to ${container_uid}:${container_gid}"
+        else
+            msgbox error "Failed to update zwift-${USER} volume owner to ${container_uid}:${container_gid}"
+            exit 1
+        fi
     fi
 fi
 

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -342,112 +342,15 @@ fi
 
 # Create array for container environment variables
 declare -a container_env_vars
-container_env_vars=()
-
-# Create array for container arguments
-declare -a container_args
-container_args=()
-
-# Create array for entrypoint arguments
-declare -a entrypoint_args
-entrypoint_args=()
-
-# Initialize user ids
-host_uid="${UID}"
-host_gid="$(id -g)"
-if [[ ${CONTAINER_TOOL} == "podman" ]]; then
-    container_uid=1000
-    container_gid=1000
-    container_args+=(--userns="keep-id:uid=${container_uid},gid=${container_gid}")
-else
-    remap_build_required() {
-        local tag_name="${1:?}"
-
-        local latest_image_digest=""
-        if ! latest_image_digest="$(${CONTAINER_TOOL} inspect "${IMAGE}:${VERSION}" --format '{{index .RepoDigests 0}}' 2> /dev/null)"; then
-            msgbox warning "Failed to get ${IMAGE}:${VERSION} image digest"
-            return 0
-        fi
-
-        local current_image_digest=""
-        if ! current_image_digest="$(${CONTAINER_TOOL} inspect "${tag_name}" --format '{{index .Config.Labels "org.opencontainers.image.base.digest"}}' 2> /dev/null))"; then
-            msgbox info "Failed to get ${tag_name} base image digest, may not exist yet"
-            return 0
-        fi
-
-        [[ ${current_image_digest} != "${latest_image_digest}" ]]
-    }
-
-    create_remap_dockerfile() {
-        local user_uid="${1:?}"
-        local user_gid="${2:?}"
-
-        local tmp_file=""
-        if ! tmp_file="$(mktemp -q /tmp/zwift-remap-user.dockerfile.XXXXXXXXXX)"; then
-            msgbox error "Failed to create dockerfile for remapping user"
-            return 1
-        fi
-
-        local image_digest=""
-        if ! image_digest="$(${CONTAINER_TOOL} inspect "${IMAGE}:${VERSION}" --format '{{index .RepoDigests 0}}' 2> /dev/null)"; then
-            msgbox warning "Failed to get ${IMAGE}:${VERSION} image digest"
-            image_digest="${IMAGE}:${VERSION}"
-        fi
-
-        {
-            echo "FROM ${IMAGE}:${VERSION}"
-            echo "USER root"
-            echo "RUN usermod -ou ${user_uid} user \\"
-            echo " && groupmod -og ${user_gid} user \\"
-            echo " && mkdir -p /run/user/${user_uid} \\"
-            echo " && chown -R user:user /run/user/${user_uid} \\"
-            echo " && sed -i \"s|/run/user/1000|/run/user/${user_uid}|g\" /etc/pulse/client.conf"
-            echo "USER user"
-            echo 'ENTRYPOINT ["entrypoint"]'
-            echo "LABEL org.opencontainers.image.base.digest=\"${image_digest}\""
-        } > "${tmp_file}"
-
-        echo "${tmp_file}"
-    }
-
-    build_remap_dockerfile() {
-        local tag_name="${1:?}"
-        local dockerfile="${2:?}"
-
-        if ${CONTAINER_TOOL} build -t "${tag_name}" -f "${dockerfile}" .; then
-            msgbox info "Created ${CONTAINER_TOOL} image ${tag_name}"
-        else
-            msgbox error "Failed to create ${CONTAINER_TOOL} image ${tag_name}"
-            return 1
-        fi
-    }
-
-    msgbox info "Remapping container user to host user"
-    container_uid="${host_uid}"
-    container_gid="${host_gid}"
-    container_image="netbrain/zwift"
-    container_image_version="remapped_user_${container_uid}_${container_gid}"
-    if remap_build_required "${container_image}:${container_image_version}"; then
-        if remap_dockerfile="$(create_remap_dockerfile "${container_uid}" "${container_gid}")" && build_remap_dockerfile "${container_image}:${container_image_version}" "${remap_dockerfile}"; then
-            msgbox ok "Remapped container user to host user"
-        else
-            msgbox error "Failed to remap container user to host user"
-            exit 1
-        fi
-    else
-        msgbox ok "${container_image}:${container_image_version} is up to date"
-    fi
-fi
-
-# Define base container environment variables
-container_env_vars+=(
+container_env_vars=(
     DEBUG="${DEBUG}"
     VERBOSITY="${VERBOSITY}"
     CONTAINER_TOOL="${CONTAINER_TOOL}"
 )
 
-# Define base container parameters
-container_args+=(
+# Create array for container arguments
+declare -a container_args
+container_args=(
     --rm
     --network "${NETWORKING}"
     --name "zwift-${USER}"
@@ -455,6 +358,10 @@ container_args+=(
     --env-file "${container_env_file}"
     -v "zwift-${USER}:${ZWIFT_DOCS}"
 )
+
+# Create array for entrypoint arguments
+declare -a entrypoint_args
+entrypoint_args=()
 
 ###################################################
 ##### Forward arguments passed to this script #####
@@ -472,6 +379,99 @@ for arg; do
         container_args+=("${arg}")
     fi
 done
+
+#############################################
+##### Remap container user to host user #####
+
+remap_build_required() {
+    local tag_name="${1:?}"
+
+    local latest_image_digest=""
+    if ! latest_image_digest="$(${CONTAINER_TOOL} inspect "${IMAGE}:${VERSION}" --format '{{index .RepoDigests 0}}' 2> /dev/null)"; then
+        msgbox warning "Failed to get ${IMAGE}:${VERSION} image digest"
+        return 0
+    fi
+
+    local current_image_digest=""
+    if ! current_image_digest="$(${CONTAINER_TOOL} inspect "${tag_name}" --format '{{index .Config.Labels "org.opencontainers.image.base.digest"}}' 2> /dev/null))"; then
+        msgbox info "Failed to get ${tag_name} base image digest, may not exist yet"
+        return 0
+    fi
+
+    [[ ${current_image_digest} != "${latest_image_digest}" ]]
+}
+
+create_remap_dockerfile() {
+    local user_uid="${1:?}"
+    local user_gid="${2:?}"
+
+    local tmp_file=""
+    if ! tmp_file="$(mktemp -q /tmp/zwift-remap-user.dockerfile.XXXXXXXXXX)"; then
+        msgbox error "Failed to create dockerfile for remapping user"
+        return 1
+    fi
+
+    local image_digest=""
+    if ! image_digest="$(${CONTAINER_TOOL} inspect "${IMAGE}:${VERSION}" --format '{{index .RepoDigests 0}}' 2> /dev/null)"; then
+        msgbox warning "Failed to get ${IMAGE}:${VERSION} image digest"
+        image_digest="${IMAGE}:${VERSION}"
+    fi
+
+    {
+        echo "FROM ${IMAGE}:${VERSION}"
+        echo "USER root"
+        echo "RUN usermod -ou ${user_uid} user \\"
+        echo " && groupmod -og ${user_gid} user \\"
+        echo " && mkdir -p /run/user/${user_uid} \\"
+        echo " && chown -R user:user /run/user/${user_uid} \\"
+        echo " && sed -i \"s|/run/user/1000|/run/user/${user_uid}|g\" /etc/pulse/client.conf"
+        echo "USER user"
+        echo 'ENTRYPOINT ["entrypoint"]'
+        echo "LABEL org.opencontainers.image.base.digest=\"${image_digest}\""
+    } > "${tmp_file}"
+
+    echo "${tmp_file}"
+}
+
+build_remap_dockerfile() {
+    local tag_name="${1:?}"
+    local dockerfile="${2:?}"
+
+    if ${CONTAINER_TOOL} build -t "${tag_name}" -f "${dockerfile}" .; then
+        msgbox info "Created ${CONTAINER_TOOL} image ${tag_name}"
+    else
+        msgbox error "Failed to create ${CONTAINER_TOOL} image ${tag_name}"
+        return 1
+    fi
+}
+
+host_uid="${UID}"
+host_gid="$(id -g)"
+
+if [[ ${CONTAINER_TOOL} == "podman" ]]; then
+    container_uid=1000
+    container_gid=1000
+
+    container_args+=(--userns="keep-id:uid=${container_uid},gid=${container_gid}")
+else
+    container_uid="${host_uid}"
+    container_gid="${host_gid}"
+
+    container_image="netbrain/zwift"
+    container_image_version="remapped_user_${container_uid}_${container_gid}"
+
+    msgbox info "Remapping container user to host user"
+    if remap_build_required "${container_image}:${container_image_version}"; then
+        if remap_dockerfile="$(create_remap_dockerfile "${container_uid}" "${container_gid}")" && build_remap_dockerfile "${container_image}:${container_image_version}" "${remap_dockerfile}"; then
+            msgbox ok "Remapped container user to host user"
+        else
+            msgbox error "Failed to remap container user to host user"
+            exit 1
+        fi
+    else
+        msgbox ok "${container_image}:${container_image_version} is up to date"
+    fi
+fi
 
 ##############################################
 ##### User defined environment variables #####

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -362,117 +362,16 @@ fi
 
 # Create array for container environment variables
 declare -a container_env_vars
-container_env_vars=()
-
-# Create array for container arguments
-declare -a container_args
-container_args=()
-
-# Create array for entrypoint arguments
-declare -a entrypoint_args
-entrypoint_args=()
-
-# Initialize user ids
-host_uid="${UID}"
-host_gid="$(id -g)"
-if [[ ${CONTAINER_TOOL} == "podman" ]]; then
-    container_uid=1000
-    container_gid=1000
-    container_args+=(--userns="keep-id:uid=${container_uid},gid=${container_gid}")
-    # Keep host supplementary groups (e.g. video/render) so GPU devices stay
-    # accessible without --privileged. On rootless podman 5.x setgroups can
-    # otherwise fail with unmapped groups. Honored by crun, ignored by runc.
-    container_args+=(--group-add keep-groups)
-else
-    remap_build_required() {
-        local tag_name="${1:?}"
-
-        local latest_image_digest=""
-        if ! latest_image_digest="$(${CONTAINER_TOOL} inspect "${IMAGE}:${VERSION}" --format '{{index .RepoDigests 0}}' 2> /dev/null)"; then
-            msgbox warning "Failed to get ${IMAGE}:${VERSION} image digest"
-            return 0
-        fi
-
-        local current_image_digest=""
-        if ! current_image_digest="$(${CONTAINER_TOOL} inspect "${tag_name}" --format '{{index .Config.Labels "org.opencontainers.image.base.digest"}}' 2> /dev/null))"; then
-            msgbox info "Failed to get ${tag_name} base image digest, may not exist yet"
-            return 0
-        fi
-
-        [[ ${current_image_digest} != "${latest_image_digest}" ]]
-    }
-
-    create_remap_dockerfile() {
-        local user_uid="${1:?}"
-        local user_gid="${2:?}"
-
-        local tmp_file=""
-        if ! tmp_file="$(mktemp -q /tmp/zwift-remap-user.dockerfile.XXXXXXXXXX)"; then
-            msgbox error "Failed to create dockerfile for remapping user"
-            return 1
-        fi
-
-        local image_digest=""
-        if ! image_digest="$(${CONTAINER_TOOL} inspect "${IMAGE}:${VERSION}" --format '{{index .RepoDigests 0}}' 2> /dev/null)"; then
-            msgbox warning "Failed to get ${IMAGE}:${VERSION} image digest"
-            image_digest="${IMAGE}:${VERSION}"
-        fi
-
-        {
-            echo "FROM ${IMAGE}:${VERSION}"
-            echo "USER root"
-            echo "RUN usermod -ou ${user_uid} user \\"
-            echo " && groupmod -og ${user_gid} user \\"
-            echo " && mkdir -p /run/user/${user_uid} \\"
-            echo " && chown -R user:user /run/user/${user_uid} \\"
-            echo " && sed -i \"s|/run/user/1000|/run/user/${user_uid}|g\" /etc/pulse/client.conf"
-            echo "USER user"
-            echo 'ENTRYPOINT ["entrypoint"]'
-            echo "LABEL org.opencontainers.image.base.digest=\"${image_digest}\""
-        } > "${tmp_file}"
-
-        echo "${tmp_file}"
-    }
-
-    build_remap_dockerfile() {
-        local tag_name="${1:?}"
-        local dockerfile="${2:?}"
-
-        if ${CONTAINER_TOOL} build -t "${tag_name}" -f "${dockerfile}" .; then
-            msgbox info "Created ${CONTAINER_TOOL} image ${tag_name}"
-        else
-            msgbox error "Failed to create ${CONTAINER_TOOL} image ${tag_name}"
-            return 1
-        fi
-    }
-
-    msgbox info "Remapping container user to host user"
-    container_uid="${host_uid}"
-    container_gid="${host_gid}"
-    container_image="netbrain/zwift"
-    container_image_version="remapped_user_${container_uid}_${container_gid}"
-    if remap_build_required "${container_image}:${container_image_version}"; then
-        if remap_dockerfile="$(create_remap_dockerfile "${container_uid}" "${container_gid}")" && build_remap_dockerfile "${container_image}:${container_image_version}" "${remap_dockerfile}"; then
-            msgbox ok "Remapped container user to host user"
-        else
-            msgbox error "Failed to remap container user to host user"
-            exit 1
-        fi
-    else
-        msgbox ok "${container_image}:${container_image_version} is up to date"
-    fi
-fi
-
-# Define base container environment variables
-container_env_vars+=(
+container_env_vars=(
     DEBUG="${DEBUG}"
     VERBOSITY="${VERBOSITY}"
     ZWIFT_VOLUME="${ZWIFT_VOLUME}"
     CONTAINER_TOOL="${CONTAINER_TOOL}"
 )
 
-# Define base container parameters
-container_args+=(
+# Create array for container arguments
+declare -a container_args
+container_args=(
     --rm
     --network "${NETWORKING}"
     --name "zwift-${ZWIFT_RIDER}"
@@ -480,6 +379,10 @@ container_args+=(
     --env-file "${container_env_file}"
     -v "zwift-${ZWIFT_RIDER}:${ZWIFT_VOLUME}"
 )
+
+# Create array for entrypoint arguments
+declare -a entrypoint_args
+entrypoint_args=()
 
 ###################################################
 ##### Forward arguments passed to this script #####
@@ -497,6 +400,104 @@ for arg; do
         container_args+=("${arg}")
     fi
 done
+
+#############################################
+##### Remap container user to host user #####
+
+remap_build_required() {
+    local tag_name="${1:?}"
+
+    local latest_image_digest=""
+    if ! latest_image_digest="$(${CONTAINER_TOOL} inspect "${IMAGE}:${VERSION}" --format '{{index .RepoDigests 0}}' 2> /dev/null)"; then
+        msgbox warning "Failed to get ${IMAGE}:${VERSION} image digest"
+        return 0
+    fi
+
+    local current_image_digest=""
+    if ! current_image_digest="$(${CONTAINER_TOOL} inspect "${tag_name}" --format '{{index .Config.Labels "org.opencontainers.image.base.digest"}}' 2> /dev/null))"; then
+        msgbox info "Failed to get ${tag_name} base image digest, may not exist yet"
+        return 0
+    fi
+
+    [[ ${current_image_digest} != "${latest_image_digest}" ]]
+}
+
+create_remap_dockerfile() {
+    local user_uid="${1:?}"
+    local user_gid="${2:?}"
+
+    local tmp_file=""
+    if ! tmp_file="$(mktemp -q /tmp/zwift-remap-user.dockerfile.XXXXXXXXXX)"; then
+        msgbox error "Failed to create dockerfile for remapping user"
+        return 1
+    fi
+
+    local image_digest=""
+    if ! image_digest="$(${CONTAINER_TOOL} inspect "${IMAGE}:${VERSION}" --format '{{index .RepoDigests 0}}' 2> /dev/null)"; then
+        msgbox warning "Failed to get ${IMAGE}:${VERSION} image digest"
+        image_digest="${IMAGE}:${VERSION}"
+    fi
+
+    {
+        echo "FROM ${IMAGE}:${VERSION}"
+        echo "USER root"
+        echo "RUN usermod -ou ${user_uid} user \\"
+        echo " && groupmod -og ${user_gid} user \\"
+        echo " && mkdir -p /run/user/${user_uid} \\"
+        echo " && chown -R user:user /run/user/${user_uid} \\"
+        echo " && sed -i \"s|/run/user/1000|/run/user/${user_uid}|g\" /etc/pulse/client.conf"
+        echo "USER user"
+        echo 'ENTRYPOINT ["entrypoint"]'
+        echo "LABEL org.opencontainers.image.base.digest=\"${image_digest}\""
+    } > "${tmp_file}"
+
+    echo "${tmp_file}"
+}
+
+build_remap_dockerfile() {
+    local tag_name="${1:?}"
+    local dockerfile="${2:?}"
+
+    if ${CONTAINER_TOOL} build -t "${tag_name}" -f "${dockerfile}" .; then
+        msgbox info "Created ${CONTAINER_TOOL} image ${tag_name}"
+    else
+        msgbox error "Failed to create ${CONTAINER_TOOL} image ${tag_name}"
+        return 1
+    fi
+}
+
+host_uid="${UID}"
+host_gid="$(id -g)"
+
+if [[ ${CONTAINER_TOOL} == "podman" ]]; then
+    container_uid=1000
+    container_gid=1000
+
+    container_args+=(--userns="keep-id:uid=${container_uid},gid=${container_gid}")
+
+    # Keep host supplementary groups (e.g. video/render) so GPU devices stay
+    # accessible without --privileged. On rootless podman 5.x setgroups can
+    # otherwise fail with unmapped groups. Honored by crun, ignored by runc.
+    container_args+=(--group-add keep-groups)
+else
+    container_uid="${host_uid}"
+    container_gid="${host_gid}"
+
+    container_image="netbrain/zwift"
+    container_image_version="remapped_user_${container_uid}_${container_gid}"
+
+    msgbox info "Remapping container user to host user"
+    if remap_build_required "${container_image}:${container_image_version}"; then
+        if remap_dockerfile="$(create_remap_dockerfile "${container_uid}" "${container_gid}")" && build_remap_dockerfile "${container_image}:${container_image_version}" "${remap_dockerfile}"; then
+            msgbox ok "Remapped container user to host user"
+        else
+            msgbox error "Failed to remap container user to host user"
+            exit 1
+        fi
+    else
+        msgbox ok "${container_image}:${container_image_version} is up to date"
+    fi
+fi
 
 ##############################################
 ##### User defined environment variables #####

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -388,13 +388,13 @@ else
         local tag_name="${1:?}"
 
         local latest_image_digest=""
-        if ! latest_image_digest="$(${CONTAINER_TOOL} inspect "${IMAGE}:${VERSION}" --format '{{.Digest}}')"; then
-            msgbox error "Failed to get ${IMAGE}:${VERSION} image digest"
-            exit 1
+        if ! latest_image_digest="$(${CONTAINER_TOOL} inspect "${IMAGE}:${VERSION}" --format '{{index .RepoDigests 0}}' 2> /dev/null)"; then
+            msgbox warning "Failed to get ${IMAGE}:${VERSION} image digest"
+            return 0
         fi
 
         local current_image_digest=""
-        if ! current_image_digest="$(${CONTAINER_TOOL} inspect "${tag_name}" --format '{{index .Config.Labels "org.opencontainers.image.base.digest"}}')"; then
+        if ! current_image_digest="$(${CONTAINER_TOOL} inspect "${tag_name}" --format '{{index .Config.Labels "org.opencontainers.image.base.digest"}}' 2> /dev/null))"; then
             msgbox info "Failed to get ${tag_name} base image digest, may not exist yet"
             return 0
         fi
@@ -413,9 +413,9 @@ else
         fi
 
         local image_digest=""
-        if ! image_digest="$(${CONTAINER_TOOL} inspect "${IMAGE}:${VERSION}" --format '{{.Digest}}')"; then
-            msgbox error "Failed to get ${IMAGE}:${VERSION} image digest"
-            return 1
+        if ! image_digest="$(${CONTAINER_TOOL} inspect "${IMAGE}:${VERSION}" --format '{{index .RepoDigests 0}}' 2> /dev/null)"; then
+            msgbox warning "Failed to get ${IMAGE}:${VERSION} image digest"
+            image_digest="${IMAGE}:${VERSION}"
         fi
 
         {

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -405,34 +405,34 @@ done
 ##### Remap container user to host user #####
 
 image_repo_digest() {
-    # Local images do not have a remote repository, will return 1
+    # Local images do not have a remote repository, will return non-zero
 
     local tag_name="${1:?}"
 
-    local repo_digest
-    repo_digest="$(${CONTAINER_TOOL} inspect "${tag_name}" --format '{{index .RepoDigests 0}}' 2> /dev/null)" || return 1
-    echo "${repo_digest}"
+    ${CONTAINER_TOOL} inspect "${tag_name}" --format '{{index .RepoDigests 0}}' 2> /dev/null
 }
 
 image_digest_label() {
     local tag_name="${1:?}"
 
-    local digest_label
-    digest_label="$(${CONTAINER_TOOL} inspect "${tag_name}" --format '{{index .Config.Labels "org.opencontainers.image.base.digest"}}' 2> /dev/null))" || return 1
-    echo "${digest_label}"
+    ${CONTAINER_TOOL} inspect "${tag_name}" --format '{{index .Config.Labels "org.opencontainers.image.base.digest"}}' 2> /dev/null
 }
 
 remap_build_required() {
     local tag_name="${1:?}"
 
     local latest_image_digest
-    if ! latest_image_digest="$(image_repo_digest "${IMAGE}:${VERSION}")"; then
+    if latest_image_digest="$(image_repo_digest "${IMAGE}:${VERSION}")"; then
+        msgbox debug "Latest image digest is ${latest_image_digest}"
+    else
         msgbox info "Failed to get ${IMAGE}:${VERSION} image repository digest, assuming rebuild is required"
         return 0
     fi
 
     local current_image_digest
-    if ! current_image_digest="$(image_digest_label "${tag_name}")"; then
+    if current_image_digest="$(image_digest_label "${tag_name}")"; then
+        msgbox debug "Base image digest is ${current_image_digest}"
+    else
         msgbox info "Failed to get ${tag_name} base image digest, may not exist yet, assuming rebuild is required"
         return 0
     fi
@@ -445,7 +445,9 @@ create_remap_dockerfile() {
     local user_gid="${2:?}"
 
     local image_digest
-    image_digest="$(image_repo_digest "${IMAGE}:${VERSION}" || echo "Unknown")"
+    if ! image_digest="$(image_repo_digest "${IMAGE}:${VERSION}")"; then
+        image_digest="Unknown"
+    fi
 
     echo "FROM ${IMAGE}:${VERSION}"
     echo "USER root"

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -530,7 +530,7 @@ fi
 volume_remap_required() {
     ${CONTAINER_TOOL} run --rm \
         -v "zwift-${ZWIFT_RIDER}:/tmp/zwift-data" \
-        -it --entrypoint bash \
+        --entrypoint bash \
         "${container_image}:${container_image_version}" \
         -c "[[ ! -O /tmp/zwift-data ]] || [[ ! -G /tmp/zwift-data ]]"
 }
@@ -539,7 +539,7 @@ remap_volume() {
     ${CONTAINER_TOOL} run --rm \
         --user root \
         -v "zwift-${ZWIFT_RIDER}:/tmp/zwift-data" \
-        -it --entrypoint bash \
+        --entrypoint bash \
         "${container_image}:${container_image_version}" \
         -c "chown -R \"${container_uid}:${container_gid}\" /tmp/zwift-data"
 }

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -451,11 +451,11 @@ create_remap_dockerfile() {
 
     echo "FROM ${IMAGE}:${VERSION}"
     echo "USER root"
-    echo "RUN usermod -ou ${user_uid} user \\"
+    echo "RUN sed -i \"s|/run/user/\$(id -u user)|/run/user/${user_uid}|g\" /etc/pulse/client.conf \\"
+    echo " && usermod -ou ${user_uid} user \\"
     echo " && groupmod -og ${user_gid} user \\"
     echo " && mkdir -p /run/user/${user_uid} \\"
-    echo " && chown -R user:user /run/user/${user_uid} \\"
-    echo " && sed -i \"s|/run/user/1000|/run/user/${user_uid}|g\" /etc/pulse/client.conf"
+    echo " && chown -R user:user /run/user/${user_uid}"
     echo "USER user"
     echo 'ENTRYPOINT ["entrypoint"]'
     echo "LABEL org.opencontainers.image.base.digest=\"${image_digest}\""

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -514,6 +514,48 @@ else
     fi
 fi
 
+# Create the volume for the zwift documents directory if it does not already exist
+if ! ${CONTAINER_TOOL} volume inspect "zwift-${ZWIFT_RIDER}" > /dev/null 2>&1; then
+    msgbox info "Creating ${CONTAINER_TOOL} volume zwift-${ZWIFT_RIDER}"
+    if ${CONTAINER_TOOL} volume create "zwift-${ZWIFT_RIDER}" > /dev/null 2>&1; then
+        msgbox ok "Created volume zwift-${ZWIFT_RIDER}"
+    else
+        msgbox error "Failed to create volume zwift-${ZWIFT_RIDER}"
+        exit 1
+    fi
+fi
+
+volume_remap_required() {
+    ${CONTAINER_TOOL} run --rm \
+        -v "zwift-${ZWIFT_RIDER}:/tmp/zwift-data" \
+        -it --entrypoint bash \
+        "${container_image}:${container_image_version}" \
+        -c "[[ ! -O /tmp/zwift-data ]] || [[ ! -G /tmp/zwift-data ]]"
+}
+
+remap_volume() {
+    ${CONTAINER_TOOL} run --rm \
+        --user root \
+        -v "zwift-${ZWIFT_RIDER}:/tmp/zwift-data" \
+        -it --entrypoint bash \
+        "${container_image}:${container_image_version}" \
+        -c "chown -R \"${container_uid}:${container_gid}\" /tmp/zwift-data"
+}
+
+# Docker: Remap volume to container user
+# Necessary in two cases:
+# - Volume was just created, owner will be root, remap required
+# - End user changed user uid/gid, remap required
+if [[ ${CONTAINER_TOOL} != "podman" ]] && volume_remap_required; then
+    msgbox info "Updating owner of volume zwift-${ZWIFT_RIDER}"
+    if remap_volume; then
+        msgbox ok "Updated zwift-${ZWIFT_RIDER} volume owner to ${container_uid}:${container_gid}"
+    else
+        msgbox error "Failed to update zwift-${ZWIFT_RIDER} volume owner to ${container_uid}:${container_gid}"
+        exit 1
+    fi
+fi
+
 ##############################################
 ##### User defined environment variables #####
 
@@ -828,26 +870,6 @@ if [[ ${DRYRUN} -eq 1 ]]; then
 else
     msgbox debug "Starting ${CONTAINER_TOOL} container with the following arguments:"
     print_container_command debug
-fi
-
-# Create the volume for the zwift documents directory if it does not already exist
-if ! ${CONTAINER_TOOL} volume inspect "zwift-${ZWIFT_RIDER}" > /dev/null 2>&1; then
-    msgbox info "Creating ${CONTAINER_TOOL} volume zwift-${ZWIFT_RIDER}"
-    if ${CONTAINER_TOOL} volume create "zwift-${ZWIFT_RIDER}" > /dev/null 2>&1; then
-        msgbox ok "Created volume zwift-${ZWIFT_RIDER}"
-    else
-        msgbox error "Failed to create volume zwift-${ZWIFT_RIDER}"
-        exit 1
-    fi
-    if [[ ${CONTAINER_TOOL} != "podman" ]]; then
-        msgbox info "Updating owner of volume zwift-${ZWIFT_RIDER}"
-        if ${CONTAINER_TOOL} run --rm --user root -it -v "zwift-${ZWIFT_RIDER}:/tmp/zwift-data" --entrypoint bash "${container_image}:${container_image_version}" -c "chown -R \"${container_uid}:${container_gid}\" /tmp/zwift-data"; then
-            msgbox ok "Updated zwift-${ZWIFT_RIDER} volume owner to ${container_uid}:${container_gid}"
-        else
-            msgbox error "Failed to update zwift-${ZWIFT_RIDER} volume owner to ${container_uid}:${container_gid}"
-            exit 1
-        fi
-    fi
 fi
 
 # Only write environment variables to file when needed

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -499,8 +499,8 @@ else
     container_uid="${host_uid}"
     container_gid="${host_gid}"
 
-    container_image="netbrain/zwift"
-    container_image_version="remapped_user_${container_uid}_${container_gid}"
+    container_image="${IMAGE#docker.io/}"
+    container_image_version="uid_${container_uid}_gid_${container_gid}"
 
     msgbox info "Remapping container user to host user"
     if remap_build_required "${container_image}:${container_image_version}"; then

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -830,15 +830,23 @@ else
     print_container_command debug
 fi
 
-# Create a volume if not already exists, this is done now as
-# if left to the run command the directory can get the wrong permissions
+# Create the volume for the zwift documents directory if it does not already exist
 if ! ${CONTAINER_TOOL} volume inspect "zwift-${ZWIFT_RIDER}" > /dev/null 2>&1; then
     msgbox info "Creating ${CONTAINER_TOOL} volume zwift-${ZWIFT_RIDER}"
-    if ${CONTAINER_TOOL} volume create "zwift-${ZWIFT_RIDER}"; then
+    if ${CONTAINER_TOOL} volume create "zwift-${ZWIFT_RIDER}" > /dev/null 2>&1; then
         msgbox ok "Created volume zwift-${ZWIFT_RIDER}"
     else
         msgbox error "Failed to create volume zwift-${ZWIFT_RIDER}"
         exit 1
+    fi
+    if [[ ${CONTAINER_TOOL} != "podman" ]]; then
+        msgbox info "Updating owner of volume zwift-${ZWIFT_RIDER}"
+        if ${CONTAINER_TOOL} run --rm --user root -it -v "zwift-${ZWIFT_RIDER}:/tmp/zwift-data" --entrypoint bash "${container_image}:${container_image_version}" -c "chown -R \"${container_uid}:${container_gid}\" /tmp/zwift-data"; then
+            msgbox ok "Updated zwift-${ZWIFT_RIDER} volume owner to ${container_uid}:${container_gid}"
+        else
+            msgbox error "Failed to update zwift-${ZWIFT_RIDER} volume owner to ${container_uid}:${container_gid}"
+            exit 1
+        fi
     fi
 fi
 

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -444,36 +444,35 @@ create_remap_dockerfile() {
     local user_uid="${1:?}"
     local user_gid="${2:?}"
 
-    local tmp_file
-    if ! tmp_file="$(mktemp -q /tmp/zwift-remap-user.dockerfile.XXXXXXXXXX)"; then
-        msgbox error "Failed to create dockerfile for remapping user"
-        return 1
-    fi
-
     local image_digest
     image_digest="$(image_repo_digest "${IMAGE}:${VERSION}" || echo "Unknown")"
 
-    {
-        echo "FROM ${IMAGE}:${VERSION}"
-        echo "USER root"
-        echo "RUN usermod -ou ${user_uid} user \\"
-        echo " && groupmod -og ${user_gid} user \\"
-        echo " && mkdir -p /run/user/${user_uid} \\"
-        echo " && chown -R user:user /run/user/${user_uid} \\"
-        echo " && sed -i \"s|/run/user/1000|/run/user/${user_uid}|g\" /etc/pulse/client.conf"
-        echo "USER user"
-        echo 'ENTRYPOINT ["entrypoint"]'
-        echo "LABEL org.opencontainers.image.base.digest=\"${image_digest}\""
-    } > "${tmp_file}"
-
-    echo "${tmp_file}"
+    echo "FROM ${IMAGE}:${VERSION}"
+    echo "USER root"
+    echo "RUN usermod -ou ${user_uid} user \\"
+    echo " && groupmod -og ${user_gid} user \\"
+    echo " && mkdir -p /run/user/${user_uid} \\"
+    echo " && chown -R user:user /run/user/${user_uid} \\"
+    echo " && sed -i \"s|/run/user/1000|/run/user/${user_uid}|g\" /etc/pulse/client.conf"
+    echo "USER user"
+    echo 'ENTRYPOINT ["entrypoint"]'
+    echo "LABEL org.opencontainers.image.base.digest=\"${image_digest}\""
 }
 
 build_remap_dockerfile() {
     local tag_name="${1:?}"
     local dockerfile="${2:?}"
 
-    if ${CONTAINER_TOOL} build -t "${tag_name}" -f "${dockerfile}" .; then
+    msgbox info "Building container image with remapped user"
+
+    msgbox debug "Using dockerfile:"
+    local dockerfile_lines line
+    readarray -t dockerfile_lines <<< "${dockerfile}"
+    for line in "${dockerfile_lines[@]}"; do
+        msgbox debug "  ${line/\\/\\\\}"
+    done
+
+    if ${CONTAINER_TOOL} build -t "${tag_name}" - <<< "${dockerfile}"; then
         msgbox info "Created ${CONTAINER_TOOL} image ${tag_name}"
     else
         msgbox error "Failed to create ${CONTAINER_TOOL} image ${tag_name}"
@@ -503,7 +502,8 @@ else
 
     msgbox info "Remapping container user to host user"
     if remap_build_required "${container_image}:${container_image_version}"; then
-        if remap_dockerfile="$(create_remap_dockerfile "${container_uid}" "${container_gid}")" && build_remap_dockerfile "${container_image}:${container_image_version}" "${remap_dockerfile}"; then
+        remap_dockerfile="$(create_remap_dockerfile "${container_uid}" "${container_gid}")"
+        if build_remap_dockerfile "${container_image}:${container_image_version}" "${remap_dockerfile}"; then
             msgbox ok "Remapped container user to host user"
         else
             msgbox error "Failed to remap container user to host user"

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -446,22 +446,20 @@ else
         fi
     }
 
+    msgbox info "Remapping container user to host user"
     container_uid="${host_uid}"
     container_gid="${host_gid}"
-    if [[ ${host_uid} -ne 1000 ]] || [[ ${host_gid} -ne 1000 ]]; then
-        msgbox info "Remapping container user to host user"
-        container_image="netbrain/zwift"
-        container_image_version="remapped_user_${container_uid}_${container_gid}"
-        if remap_build_required "${container_image}:${container_image_version}"; then
-            if remap_dockerfile="$(create_remap_dockerfile "${container_uid}" "${container_gid}")" && build_remap_dockerfile "${container_image}:${container_image_version}" "${remap_dockerfile}"; then
-                msgbox ok "Remapped container user to host user"
-            else
-                msgbox error "Failed to remap container user to host user"
-                exit 1
-            fi
+    container_image="netbrain/zwift"
+    container_image_version="remapped_user_${container_uid}_${container_gid}"
+    if remap_build_required "${container_image}:${container_image_version}"; then
+        if remap_dockerfile="$(create_remap_dockerfile "${container_uid}" "${container_gid}")" && build_remap_dockerfile "${container_image}:${container_image_version}" "${remap_dockerfile}"; then
+            msgbox ok "Remapped container user to host user"
         else
-            msgbox ok "${container_image}:${container_image_version} is up to date"
+            msgbox error "Failed to remap container user to host user"
+            exit 1
         fi
+    else
+        msgbox ok "${container_image}:${container_image_version} is up to date"
     fi
 fi
 

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -381,10 +381,53 @@ if [[ ${CONTAINER_TOOL} == "podman" ]]; then
     container_args+=(--group-add keep-groups)
 else
     container_uid="${host_uid}"
-    container_env_vars+=(
-        HOST_UID="${host_uid}"
-        HOST_GID="${host_gid}"
-    )
+    tmp_dockerfile=""
+
+    cleanup_remap_container() {
+        msgbox info "Removing temporary container zwift-remap-user"
+        ${CONTAINER_TOOL} rm zwift-remap-user || true
+
+        msgbox info "Removing temporary image zwift-remap-user-image"
+        ${CONTAINER_TOOL} image rm zwift-remap-user-image || true
+
+        msgbox info "Removing temporary dockerfile"
+        [[ -n ${tmp_dockerfile} ]] && [[ -f ${tmp_dockerfile} ]] && rm -f -- "${tmp_dockerfile}" || true
+    }
+
+    if ! tmp_dockerfile="$(mktemp -q /tmp/zwift-remap-user.dockerfile.XXXXXXXXXX)" || ! echo -e "FROM ${IMAGE}:${VERSION}\nUSER root\n ENTRYPOINT [\"entrypoint\"]" > "${tmp_dockerfile}"; then
+        msgbox error "Failed to create temporary dockerfile"
+        cleanup_remap_container
+        exit 1
+    fi
+
+    msgbox info "Creating image to remap user"
+    if ${CONTAINER_TOOL} build -t zwift-remap-user-image -f "${tmp_dockerfile}" .; then
+        msgbox ok "Created image to remap user"
+    else
+        msgbox error "Failed to create image to remap user"
+        cleanup_remap_container
+        exit 1
+    fi
+
+    msgbox info "Remapping container user to host user"
+    if ${CONTAINER_TOOL} run --name zwift-remap-user -e CONTAINER_TOOL="${CONTAINER_TOOL}" -e DEBUG="${DEBUG}" -e VERBOSITY="${VERBOSITY}" -e HOST_UID="${host_uid}" -e HOST_GID="${host_gid}" zwift-remap-user-image --remap-user; then
+        msgbox ok "Remapped container user to host user"
+    else
+        msgbox error "Failed to remap container user to host user"
+        cleanup_remap_container
+        exit 1
+    fi
+
+    msgbox info "Persisting container with remapped user"
+    if ${CONTAINER_TOOL} commit --change="USER user" --change='CMD [""]' -m "Remapped user to ${host_uid}:${host_gid}" zwift-remap-user "${IMAGE}:${VERSION}"; then
+        msgbox ok "Persisted container with remapped user"
+    else
+        msgbox error "Failed to persist container with remapped user"
+        cleanup_remap_container
+        exit 1
+    fi
+
+    cleanup_remap_container
 fi
 
 # Define base container environment variables

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -384,13 +384,37 @@ if [[ ${CONTAINER_TOOL} == "podman" ]]; then
     # otherwise fail with unmapped groups. Honored by crun, ignored by runc.
     container_args+=(--group-add keep-groups)
 else
+    remap_build_required() {
+        local tag_name="${1:?}"
+
+        local latest_image_digest=""
+        if ! latest_image_digest="$(${CONTAINER_TOOL} inspect "${IMAGE}:${VERSION}" --format '{{.Digest}}')"; then
+            msgbox error "Failed to get ${IMAGE}:${VERSION} image digest"
+            exit 1
+        fi
+
+        local current_image_digest=""
+        if ! current_image_digest="$(${CONTAINER_TOOL} inspect "${tag_name}" --format '{{index .Config.Labels "org.opencontainers.image.base.digest"}}')"; then
+            msgbox info "Failed to get ${tag_name} base image digest, may not exist yet"
+            return 0
+        fi
+
+        [[ ${current_image_digest} != "${latest_image_digest}" ]]
+    }
+
     create_remap_dockerfile() {
         local user_uid="${1:?}"
         local user_gid="${2:?}"
-        local tmp_file=""
 
+        local tmp_file=""
         if ! tmp_file="$(mktemp -q /tmp/zwift-remap-user.dockerfile.XXXXXXXXXX)"; then
             msgbox error "Failed to create dockerfile for remapping user"
+            return 1
+        fi
+
+        local image_digest=""
+        if ! image_digest="$(${CONTAINER_TOOL} inspect "${IMAGE}:${VERSION}" --format '{{.Digest}}')"; then
+            msgbox error "Failed to get ${IMAGE}:${VERSION} image digest"
             return 1
         fi
 
@@ -404,6 +428,7 @@ else
             echo " && sed -i \"s|/run/user/1000|/run/user/${user_uid}|g\" /etc/pulse/client.conf"
             echo "USER user"
             echo 'ENTRYPOINT ["entrypoint"]'
+            echo "LABEL org.opencontainers.image.base.digest=\"${image_digest}\""
         } > "${tmp_file}"
 
         echo "${tmp_file}"
@@ -427,11 +452,15 @@ else
         msgbox info "Remapping container user to host user"
         container_image="netbrain/zwift"
         container_image_version="remapped_user_${container_uid}_${container_gid}"
-        if remap_dockerfile="$(create_remap_dockerfile "${container_uid}" "${container_gid}")" && build_remap_dockerfile "${container_image}:${container_image_version}" "${remap_dockerfile}"; then
-            msgbox ok "Remapped container user to host user"
+        if remap_build_required "${container_image}:${container_image_version}"; then
+            if remap_dockerfile="$(create_remap_dockerfile "${container_uid}" "${container_gid}")" && build_remap_dockerfile "${container_image}:${container_image_version}" "${remap_dockerfile}"; then
+                msgbox ok "Remapped container user to host user"
+            else
+                msgbox error "Failed to remap container user to host user"
+                exit 1
+            fi
         else
-            msgbox error "Failed to remap container user to host user"
-            exit 1
+            msgbox ok "${container_image}:${container_image_version} is up to date"
         fi
     fi
 fi

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -404,18 +404,36 @@ done
 #############################################
 ##### Remap container user to host user #####
 
+image_repo_digest() {
+    # Local images do not have a remote repository, will return 1
+
+    local tag_name="${1:?}"
+
+    local repo_digest
+    repo_digest="$(${CONTAINER_TOOL} inspect "${tag_name}" --format '{{index .RepoDigests 0}}' 2> /dev/null)" || return 1
+    echo "${repo_digest}"
+}
+
+image_digest_label() {
+    local tag_name="${1:?}"
+
+    local digest_label
+    digest_label="$(${CONTAINER_TOOL} inspect "${tag_name}" --format '{{index .Config.Labels "org.opencontainers.image.base.digest"}}' 2> /dev/null))" || return 1
+    echo "${digest_label}"
+}
+
 remap_build_required() {
     local tag_name="${1:?}"
 
-    local latest_image_digest=""
-    if ! latest_image_digest="$(${CONTAINER_TOOL} inspect "${IMAGE}:${VERSION}" --format '{{index .RepoDigests 0}}' 2> /dev/null)"; then
-        msgbox warning "Failed to get ${IMAGE}:${VERSION} image digest"
+    local latest_image_digest
+    if ! latest_image_digest="$(image_repo_digest "${IMAGE}:${VERSION}")"; then
+        msgbox info "Failed to get ${IMAGE}:${VERSION} image repository digest, assuming rebuild is required"
         return 0
     fi
 
-    local current_image_digest=""
-    if ! current_image_digest="$(${CONTAINER_TOOL} inspect "${tag_name}" --format '{{index .Config.Labels "org.opencontainers.image.base.digest"}}' 2> /dev/null))"; then
-        msgbox info "Failed to get ${tag_name} base image digest, may not exist yet"
+    local current_image_digest
+    if ! current_image_digest="$(image_digest_label "${tag_name}")"; then
+        msgbox info "Failed to get ${tag_name} base image digest, may not exist yet, assuming rebuild is required"
         return 0
     fi
 
@@ -426,17 +444,14 @@ create_remap_dockerfile() {
     local user_uid="${1:?}"
     local user_gid="${2:?}"
 
-    local tmp_file=""
+    local tmp_file
     if ! tmp_file="$(mktemp -q /tmp/zwift-remap-user.dockerfile.XXXXXXXXXX)"; then
         msgbox error "Failed to create dockerfile for remapping user"
         return 1
     fi
 
-    local image_digest=""
-    if ! image_digest="$(${CONTAINER_TOOL} inspect "${IMAGE}:${VERSION}" --format '{{index .RepoDigests 0}}' 2> /dev/null)"; then
-        msgbox warning "Failed to get ${IMAGE}:${VERSION} image digest"
-        image_digest="${IMAGE}:${VERSION}"
-    fi
+    local image_digest
+    image_digest="$(image_repo_digest "${IMAGE}:${VERSION}" || echo "Unknown")"
 
     {
         echo "FROM ${IMAGE}:${VERSION}"

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -184,10 +184,17 @@ readonly ZWIFT_FG="${ZWIFT_FG:-0}"
 readonly ZWIFT_NO_GAMEMODE="${ZWIFT_NO_GAMEMODE:-0}"
 readonly WINE_EXPERIMENTAL_WAYLAND="${WINE_EXPERIMENTAL_WAYLAND:-0}"
 readonly NETWORKING="${NETWORKING:-bridge}"
-readonly ZWIFT_UID="${ZWIFT_UID:-${UID}}"
-readonly ZWIFT_GID="${ZWIFT_GID:-$(id -g)}"
 readonly VGA_DEVICE_FLAG="${VGA_DEVICE_FLAG:-}"
 readonly PRIVILEGED_CONTAINER="${PRIVILEGED_CONTAINER:-0}"
+
+# No longer supported configuration environment variables
+readonly ZWIFT_UID="${ZWIFT_UID:-}"
+readonly ZWIFT_GID="${ZWIFT_GID:-}"
+if [[ -n ${ZWIFT_UID} ]] || [[ -n ${ZWIFT_GID} ]]; then
+    msgbox error "ZWIFT_UID and ZWIFT_GID options are no longer supported"
+    msgbox error "  To start Zwift as a different user, use: sudo -i username zwift"
+    exit 1
+fi
 
 # Initialize CONTAINER_TOOL: Use podman if available
 msgbox info "Looking for container tool"
@@ -215,8 +222,8 @@ declare -a parameters_to_print
 parameters_to_print=(
     DEBUG VERBOSITY CONTAINER_TOOL IMAGE VERSION SCRIPT_VERSION DONT_CHECK DONT_PULL DONT_CLEAN DRYRUN INTERACTIVE
     CONTAINER_EXTRA_ARGS ZWIFT_RIDER ZWIFT_USERNAME ZWIFT_PASSWORD ZWIFT_WORKOUT_DIR ZWIFT_ACTIVITY_DIR ZWIFT_LOG_DIR ZWIFT_SCREENSHOTS_DIR
-    ZWIFT_OVERRIDE_GRAPHICS ZWIFT_OVERRIDE_RESOLUTION ZWIFT_FG ZWIFT_NO_GAMEMODE WINE_EXPERIMENTAL_WAYLAND NETWORKING ZWIFT_UID
-    ZWIFT_GID VGA_DEVICE_FLAG PRIVILEGED_CONTAINER DBUS_SESSION_BUS_ADDRESS DISPLAY WAYLAND_DISPLAY XAUTHORITY XDG_RUNTIME_DIR
+    ZWIFT_OVERRIDE_GRAPHICS ZWIFT_OVERRIDE_RESOLUTION ZWIFT_FG ZWIFT_NO_GAMEMODE WINE_EXPERIMENTAL_WAYLAND NETWORKINGD VGA_DEVICE_FLAG
+    PRIVILEGED_CONTAINER DBUS_SESSION_BUS_ADDRESS DISPLAY WAYLAND_DISPLAY XAUTHORITY XDG_RUNTIME_DIR
 )
 for parameter_to_print in "${parameters_to_print[@]}"; do
     parameter_print_value="$(declare -p "${parameter_to_print}")"
@@ -362,22 +369,22 @@ container_args=()
 declare -a entrypoint_args
 entrypoint_args=()
 
+# Initialize user ids
+host_uid="${UID}"
+host_gid="$(id -g)"
 if [[ ${CONTAINER_TOOL} == "podman" ]]; then
-    # Podman has to use container id 1000
-    # Local user is mapped to the container id
-    local_uid="${ZWIFT_UID}"
     container_uid=1000
-    container_gid=1000
-    container_args+=(--userns "keep-id:uid=${container_uid},gid=${container_gid}")
+    container_args+=(--userns "keep-id:uid=1000,gid=1000")
     # Keep host supplementary groups (e.g. video/render) so GPU devices stay
     # accessible without --privileged. On rootless podman 5.x setgroups can
     # otherwise fail with unmapped groups. Honored by crun, ignored by runc.
     container_args+=(--group-add keep-groups)
 else
-    # Docker will run as the id's provided.
-    local_uid="${UID}"
-    container_uid="${ZWIFT_UID}"
-    container_gid="${ZWIFT_GID}"
+    container_uid="${host_uid}"
+    container_env_vars+=(
+        HOST_UID="${host_uid}"
+        HOST_GID="${host_gid}"
+    )
 fi
 
 # Define base container environment variables
@@ -385,8 +392,6 @@ container_env_vars+=(
     DEBUG="${DEBUG}"
     VERBOSITY="${VERBOSITY}"
     ZWIFT_VOLUME="${ZWIFT_VOLUME}"
-    ZWIFT_UID="${container_uid}"
-    ZWIFT_GID="${container_gid}"
     CONTAINER_TOOL="${CONTAINER_TOOL}"
 )
 
@@ -624,18 +629,13 @@ fi
 if [[ ${window_manager} == "Wayland" ]]; then
     msgbox info "Using Wayland window manager"
 
-    if [[ ${ZWIFT_UID} -ne ${UID} ]]; then
-        msgbox error "Wayland does not support ZWIFT_UID different to your id of ${UID}"
-        exit 1
-    fi
-
     if [[ -n ${XDG_RUNTIME_DIR} ]] && [[ -n ${WAYLAND_DISPLAY} ]]; then
         container_env_vars+=(
-            XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR//${local_uid}/${container_uid}}"
+            XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR//${host_uid}/${container_uid}}"
             WAYLAND_DISPLAY="${WAYLAND_DISPLAY}"
             WINE_EXPERIMENTAL_WAYLAND="1"
         )
-        container_args+=(-v "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}:${XDG_RUNTIME_DIR//${local_uid}/${container_uid}}/${WAYLAND_DISPLAY}")
+        container_args+=(-v "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}:${XDG_RUNTIME_DIR//${host_uid}/${container_uid}}/${WAYLAND_DISPLAY}")
     else
         msgbox error "Required environment variables XDG_RUNTIME_DIR and/or WAYLAND_DISPLAY are not set"
         msgbox error "Falling back to XWayland" 5
@@ -662,8 +662,8 @@ if [[ ${window_manager} == "XWayland" ]] || [[ ${window_manager} == "XOrg" ]]; t
     fi
 
     if [[ -n ${XAUTHORITY} ]]; then
-        container_env_vars+=(XAUTHORITY="${XAUTHORITY//${local_uid}/${container_uid}}")
-        container_args+=(-v "${XAUTHORITY}:${XAUTHORITY//${local_uid}/${container_uid}}")
+        container_env_vars+=(XAUTHORITY="${XAUTHORITY//${host_uid}/${container_uid}}")
+        container_args+=(-v "${XAUTHORITY}:${XAUTHORITY//${host_uid}/${container_uid}}")
     else
         msgbox info "XAUTHORITY environment variable not set, container access to X11 needs to be granted with xhost"
         xhost_access_required=1
@@ -678,17 +678,17 @@ if [[ -n ${DBUS_SESSION_BUS_ADDRESS} ]]; then
     [[ ${DBUS_SESSION_BUS_ADDRESS} =~ ^unix:path=([^,]+) ]]
     dbus_unix_socket=${BASH_REMATCH[1]}
     if [[ -n ${dbus_unix_socket} ]]; then
-        container_env_vars+=(DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS//${local_uid}/${container_uid}}")
-        container_args+=(-v "${dbus_unix_socket}:${dbus_unix_socket//${local_uid}/${container_uid}}")
+        container_env_vars+=(DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS//${host_uid}/${container_uid}}")
+        container_args+=(-v "${dbus_unix_socket}:${dbus_unix_socket//${host_uid}/${container_uid}}")
     fi
 fi
 
 # Configure sound driver
 container_env_vars+=(PULSE_SERVER="/run/user/${container_uid}/pulse/native")
-if [[ -d "/run/user/${local_uid}/pulse" ]]; then
-    container_args+=(-v "/run/user/${local_uid}/pulse:/run/user/${container_uid}/pulse")
+if [[ -d "/run/user/${host_uid}/pulse" ]]; then
+    container_args+=(-v "/run/user/${host_uid}/pulse:/run/user/${container_uid}/pulse")
 else
-    msgbox warning "PulseAudio socket /run/user/${local_uid}/pulse not found — audio may not work (PipeWire-only system?)"
+    msgbox warning "PulseAudio socket /run/user/${host_uid}/pulse not found — audio may not work (PipeWire-only system?)"
 fi
 
 # Check for proprietary nvidia driver and set correct device to use (respects existing VGA_DEVICE_FLAG)

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -343,6 +343,9 @@ if [[ ${DONT_CLEAN} -ne 1 ]] && [[ ${DONT_PULL} -ne 1 ]]; then
     fi
 fi
 
+container_image="${IMAGE}"
+container_image_version="${VERSION}"
+
 ###############################
 ##### Basic configuration #####
 
@@ -374,60 +377,63 @@ host_uid="${UID}"
 host_gid="$(id -g)"
 if [[ ${CONTAINER_TOOL} == "podman" ]]; then
     container_uid=1000
-    container_args+=(--userns "keep-id:uid=1000,gid=1000")
+    container_gid=1000
+    container_args+=(--userns="keep-id:uid=${container_uid},gid=${container_gid}")
     # Keep host supplementary groups (e.g. video/render) so GPU devices stay
     # accessible without --privileged. On rootless podman 5.x setgroups can
     # otherwise fail with unmapped groups. Honored by crun, ignored by runc.
     container_args+=(--group-add keep-groups)
 else
-    container_uid="${host_uid}"
-    tmp_dockerfile=""
+    create_remap_dockerfile() {
+        local user_uid="${1:?}"
+        local user_gid="${2:?}"
+        local tmp_file=""
 
-    cleanup_remap_container() {
-        msgbox info "Removing temporary container zwift-remap-user"
-        ${CONTAINER_TOOL} rm zwift-remap-user || true
+        if ! tmp_file="$(mktemp -q /tmp/zwift-remap-user.dockerfile.XXXXXXXXXX)"; then
+            msgbox error "Failed to create dockerfile for remapping user"
+            return 1
+        fi
 
-        msgbox info "Removing temporary image zwift-remap-user-image"
-        ${CONTAINER_TOOL} image rm zwift-remap-user-image || true
+        {
+            echo "FROM ${IMAGE}:${VERSION}"
+            echo "USER root"
+            echo "RUN usermod -ou ${user_uid} user \\"
+            echo " && groupmod -og ${user_gid} user \\"
+            echo " && mkdir -p /run/user/${user_uid} \\"
+            echo " && chown -R user:user /run/user/${user_uid} \\"
+            echo " && sed -i \"s|/run/user/1000|/run/user/${user_uid}|g\" /etc/pulse/client.conf"
+            echo "USER user"
+            echo 'ENTRYPOINT ["entrypoint"]'
+        } > "${tmp_file}"
 
-        msgbox info "Removing temporary dockerfile"
-        [[ -n ${tmp_dockerfile} ]] && [[ -f ${tmp_dockerfile} ]] && rm -f -- "${tmp_dockerfile}" || true
+        echo "${tmp_file}"
     }
 
-    if ! tmp_dockerfile="$(mktemp -q /tmp/zwift-remap-user.dockerfile.XXXXXXXXXX)" || ! echo -e "FROM ${IMAGE}:${VERSION}\nUSER root\n ENTRYPOINT [\"entrypoint\"]" > "${tmp_dockerfile}"; then
-        msgbox error "Failed to create temporary dockerfile"
-        cleanup_remap_container
-        exit 1
-    fi
+    build_remap_dockerfile() {
+        local tag_name="${1:?}"
+        local dockerfile="${2:?}"
 
-    msgbox info "Creating image to remap user"
-    if ${CONTAINER_TOOL} build -t zwift-remap-user-image -f "${tmp_dockerfile}" .; then
-        msgbox ok "Created image to remap user"
-    else
-        msgbox error "Failed to create image to remap user"
-        cleanup_remap_container
-        exit 1
-    fi
+        if ${CONTAINER_TOOL} build -t "${tag_name}" -f "${dockerfile}" .; then
+            msgbox info "Created ${CONTAINER_TOOL} image ${tag_name}"
+        else
+            msgbox error "Failed to create ${CONTAINER_TOOL} image ${tag_name}"
+            return 1
+        fi
+    }
 
-    msgbox info "Remapping container user to host user"
-    if ${CONTAINER_TOOL} run --name zwift-remap-user -e CONTAINER_TOOL="${CONTAINER_TOOL}" -e DEBUG="${DEBUG}" -e VERBOSITY="${VERBOSITY}" -e HOST_UID="${host_uid}" -e HOST_GID="${host_gid}" zwift-remap-user-image --remap-user; then
-        msgbox ok "Remapped container user to host user"
-    else
-        msgbox error "Failed to remap container user to host user"
-        cleanup_remap_container
-        exit 1
+    container_uid="${host_uid}"
+    container_gid="${host_gid}"
+    if [[ ${host_uid} -ne 1000 ]] || [[ ${host_gid} -ne 1000 ]]; then
+        msgbox info "Remapping container user to host user"
+        container_image="netbrain/zwift"
+        container_image_version="remapped_user_${container_uid}_${container_gid}"
+        if remap_dockerfile="$(create_remap_dockerfile "${container_uid}" "${container_gid}")" && build_remap_dockerfile "${container_image}:${container_image_version}" "${remap_dockerfile}"; then
+            msgbox ok "Remapped container user to host user"
+        else
+            msgbox error "Failed to remap container user to host user"
+            exit 1
+        fi
     fi
-
-    msgbox info "Persisting container with remapped user"
-    if ${CONTAINER_TOOL} commit --change="USER user" --change='CMD [""]' -m "Remapped user to ${host_uid}:${host_gid}" zwift-remap-user "${IMAGE}:${VERSION}"; then
-        msgbox ok "Persisted container with remapped user"
-    else
-        msgbox error "Failed to persist container with remapped user"
-        cleanup_remap_container
-        exit 1
-    fi
-
-    cleanup_remap_container
 fi
 
 # Define base container environment variables
@@ -754,7 +760,7 @@ fi
 ##### Start container #####
 
 declare -a container_command
-container_command=("${CONTAINER_TOOL}" run "${container_args[@]}" "${IMAGE}:${VERSION}" "${entrypoint_args[@]}")
+container_command=("${CONTAINER_TOOL}" run "${container_args[@]}" "${container_image}:${container_image_version}" "${entrypoint_args[@]}")
 
 # Print the exact command that would be executed
 


### PR DESCRIPTION
Related to #315.

> **Spoiler**: It's not just 25 lines of code.

## Summary

This PR refactors how we deal with UIDs and GIDs.

Current implementation:

- Podman: Can automatically remap ids, and we use this feature
- Docker: Does not support remapping ids out of the box, container starts as root, then reown and switch user

New implementation:

- Podman: No change
- Docker:
  - Start container as user instead of root (user also no longer has root privileges)
  - Entrypoint no longer has root access, don't reown anything and no need to switch user
  - In the zwift.sh script: Remap the container UID/GID using a temporary dockerfile if needed
  - In the zwift.sh script: Remap the volume UID/GID if needed

> **Important**: This change is NOT compatible with the end user requesting Zwift to run with different ids than the ids of $USER. So support for the ZWIFT_UID and ZWIFT_GID configuration options has been removed. A real user is required, use `sudo -u other_user zwift` instead of `ZWIFT_UID=other_user_uid ZWIFT_GID=other_user_gid zwift`.

## Implementation

### Exit with error when ZWIFT_UID or ZWIFT_GID are set

We now remap the container user to the host user. This does not work with custom ids.

If the end user has a ZWIFT_UID or ZWIFT_GID set, report an error that they are no longer supported and exit the zwift script. The end user has to remove these configuration options to be able to continue using zwift.

### Building the image locally using build-image.sh

The build script is fragile when the host user has a UID/GID that is not equal to 1000:1000. For example the XAUTHORITY cookie may not work, resulting in the installer not having access to X11. This problem is exagerated if the end user manually sets a ZWIFT_UID/ZWIFT_GID. Currently the only safe way to use the build script is with a host user that has UID/GID 1000:1000.

Since we know the UID/GID in advance, we might as well take advantage of it and pass them as build argument to the Dockerfile. We immediately create the container user with the correct UID/GID. This in combination with no longer allowing the end user to specify a ZWIFT_UID/ZWIFT_GID makes it safe to use the build script on a local user with UID/GID not equal to 1000:1000.

> **Important**: When docker is used as container tool, we can therefore no longer assume that the UID/GID of container user is 1000:1000.

> **Important**: No change when the container tool is podman. The container user ALWAYS has UID/GID 1000:1000.

### Don't launch container as root, use user instead

The following changes were made to the container user:

- Don't give root access to the container user, it's not needed
- Use a USER directive to automatically switch to user instead of starting as root

> **Advantage**: No root access inside the container, making privilege escalation less likely.

> **Note**: If root access to the container is required, the end user can still do so by using `docker exec --user root`.

```Dockerfile
# Build script: Allow specifying the UID and GID to use
ARG USER_UID=1000
ARG USER_GID=1000

# Create user with UID and GID, but NO root access
RUN addgroup --gid ${USER_GID} user \
 && adduser --uid ${USER_UID} --gid ${USER_GID} --disabled-password --comment '' user

# Switch to user (starts container as user with both docker and podman)
USER user
```

> **Important**: The entrypoint script is now launched as user and no longer has root privileges. It can no longer be used to change ownership.

### Changing ownership: Remapping the container user to the host user

Since the entrypoint script now runs as user instead of root, it can't perform a chown. We now remap the container to the host user in the zwift script instead.

The remapping is done in two stages.

#### 1. Remap the container user to the host user by changing its UID/GID to be the same as the host user UID/GID.

We perform this remapping using a simple dockerfile that starts from the requested IMAGE and VERSION (default: docker.io/netbrain/zwift). The dockerfile temporarily switches the USER to root to execute the same commands that used to be executed in the entrypoint script. These commands change the container user UID/GID to be the same as the host user UID/GID. Before switching the USER back to user. The dockerfile is generated on the fly when needed.

A label is also attached with the repository image digest of the requested zwift image IMAGE:VERSION. The remapping only has to be done if the image digest changed (IMAGE:VERSION changed).

```Dockerfile
# user_uid = host user uid
# user_gid = host user gid
# image_digest = ${IMAGE}:${VERSION} repository digest
   
FROM ${IMAGE}:${VERSION}
USER root
RUN usermod -ou ${user_uid} user \
 && groupmod -og ${user_gid} user \
 && mkdir -p /run/user/${user_uid} \
 && chown -R user:user /run/user/${user_uid} \
 && sed -i "s|/run/user/1000|/run/user/${user_uid}|g" /etc/pulse/client.conf
USER user
ENTRYPOINT ["entrypoint"]
LABEL org.opencontainers.image.base.digest="${image_digest}"
```
> **Question**: The `mkdir -p /run/user/${user_uid}` and `chown -R user:user /run/user/${user_uid}` were also done in the entrypoint. But are the actually needed?

The freshly built image is tagged as `netbrain/zwift:remapped_user_$UID_$GID` and used to launch zwift instead of IMAGE:VERSION. Including the UID/GID in the tag name is important for several reasons:

- So we know if an image with the correct UID/GID already exists. Otherwise we would always have to rebuild since we cannot know if the end user launched as a different user this time or if he changed the UID/GID of his account.
- If the end user wants to be able to use zwift on multiple users, we don't want to constantly overwrite the tag. This would also break things if the end user wants to launch multiple zwift instances at the same time.

> **Important**: The remapping also has to be done for host users with UID/GID 1000:1000 since we can no longer assume that the container user was created with UID/GID 1000:1000. The performance overhead is negligible (remapping is super fast if ids have not changed).

> **Important**: If the user uses a local IMAGE:VERSION (instead of one that is published on docker hub or another registry), there is no repository digest. So the remapping will be done each launch (if nothing changed, the overhead is negligibly). This, for example, is the case when building the image locally using the build script.

#### 2. Make sure the ownership of the zwift-$USER volume is correct

We also need to make sure the UID/GID of the zwift documents directory, mounted from the zwift-$USER volume, is correct. To check its UID/GID, we mount it in a temporary container. If the UID/GID turns out to be wrong, another temporary container is launched, this time with root user, and a recursive chown is performed.

- Check if the zwift-$USER volume UID/GID is correct:

  ```bash
  docker run \
      --rm \
      -it \
      -v zwift-$USER:/zwift-docs \
      --entrypoint bash \
      netbrain/zwift:remapped_user_$UID_$GID \
      -c "[[ ! -O /zwift-docs ]] || [[ ! -G /zwift-docs ]]"
  ```

- Update the zwift-$USER volume UID/GID:

  ```bash
  docker run \
      --rm \
      --user root \
      -it \
      -v zwift-$USER:/zwift-docs \
      --entrypoint bash \
      netbrain/zwift:remapped_user_$UID_$GID \
      -c "chown -R $UID:$GID /zwift-docs"
  ```

The check whether the UID/GID of the volume are correct is always performed. There are two situations where remapping is actually required:

- The zwift-$USER volume is initially created as root. This is the case even if the container is launched as user. Se we cannot rely on the run command to automatically create the volume correctly. Instead we manually create the volume if it does not already exists (we already did this for podman) and then update the UID/GID.
- If the end user changes his UID/GID, the ids in the container and volume will no longer be correct. The dockerfile will execute to remap the container user and we also have to chown the volume.

> **Note**: The run_zwift script now also checks the UID/GID of the zwift documents directory. If they are incorrect it reports an error and exits.

## Other changes

Just two minor changes I smuggled into this PR:

* Reformat the default graphics profile a bit to make it more readable.
* When DRYRUN is not set, print the environment variables and command as debug messages.