### PR TITLE
Update GitHub actions and fix dockerhub prune workflow

### DIFF
--- a/.github/workflows/dockerhub_prune.yaml
+++ b/.github/workflows/dockerhub_prune.yaml
@@ -59,8 +59,7 @@ jobs:
                         -H "Authorization: Bearer ${token}")"
 
                     if [[ ${http_code} -eq 204 ]]; then
-                        echo "  Deleted successfully"
-                        ((deleted++))
+                        ((deleted++)) || true
                     else
                         echo "::warning::Failed to delete tag ${tag} (HTTP ${http_code})"
                     fi
@@ -73,7 +72,7 @@ jobs:
             if [[ -z ${next} ]]; then
                 break
             fi
-            ((page++))
+            ((page++)) || true
         done
 
         echo "Pruned ${deleted} tag(s)"

--- a/.github/workflows/github_pages.yaml
+++ b/.github/workflows/github_pages.yaml
@@ -53,4 +53,4 @@ jobs:
     steps:
     - name: Deploy to github pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@v5

--- a/.github/workflows/github_pages.yaml
+++ b/.github/workflows/github_pages.yaml
@@ -33,7 +33,7 @@ jobs:
         working-directory: ${{ github.workspace }}/docs
     - name: Setup Pages
       id: pages
-      uses: actions/configure-pages@v5
+      uses: actions/configure-pages@v6
     - name: Build with Jekyll
       run: |
         bundle install

--- a/.github/workflows/lint_everything.yaml
+++ b/.github/workflows/lint_everything.yaml
@@ -70,7 +70,7 @@ jobs:
     - name: Checkout repository code
       uses: actions/checkout@v6
     - name: Check markdown files for errors
-      uses: DavidAnson/markdownlint-cli2-action@v22
+      uses: DavidAnson/markdownlint-cli2-action@v23
       with:
         config: .markdownlint-cli2.yaml
         globs: ''


### PR DESCRIPTION
## Summary

- Update remaining github actions (see #319 for context).
- Fix issue in dockerhub prune action.

## Implementation

### Update github actions

All remaining github actions have been updated to node 24.

- [DavidAnson/markdownlint-cli2-action](https://github.com/DavidAnson/markdownlint-cli2-action) @ v23
- [actions/configure-pages](https://github.com/actions/configure-pages) @ v6
- [actions/deploy-pages](https://github.com/actions/deploy-pages) @ v5

### Fix dockerhub prune issue

#### Failure

The [docker hub prune](https://github.com/netbrain/zwift/actions/workflows/dockerhub_prune.yaml) workflow fails in two cases:

- When there is at least one old image that should be deleted (because of `((deleted++))`).
- When there are multiple pages of images (because of `((pages++))`).

#### Reason

`set -e` is enabled by default for github workflows

- `set -e` causes the workflow to exit early if a command returns a non-zero value.
- Arithmetic operations return their result instead of a status code indicating success or failure.

#### Demo

```bash
#!/usr/bin/env bash
set -euo pipefail

i=0
echo "1. i is ${i}"    # ok, prints 1. i is 0
((i++))                # 0++ = 1 --> returns 1 --> set -e makes script exit
echo "2. i is ${i}"    # never executed
```

#### Workaround

```bash
#!/usr/bin/env bash
set -euo pipefail

i=0
echo "1. i is ${i}"    # ok, prints 1. i is 0
((i++)) || true        # 0++ = 1 --> returns 1 --> || true --> returns 0 --> ok
echo "2. i is ${i}"    # ok, prints 2. i is 1
```

#### Solution

Append `|| true` to arithmetic operations

- `((deleted++))` --> `((deleted++)) || true`
- `((page++))` --> `((page++)) || true`