### PR TITLE
Fix zwift install error with docker

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -142,7 +142,7 @@ if [[ ${CONTAINER_TOOL} == "docker" ]]; then
         # This avoids a costly recursive find on every normal startup
         local target="${1:?}"
         local result
-        [[ -d ${target} ]] && result="$(find "${target}" -maxdepth 0 \( ! -user user -o ! -group user \) -print 2> /dev/null)" && [[ -n ${result} ]]
+        [[ -d ${target} ]] && result="$(find "${target}" -maxdepth 1 \( ! -user user -o ! -group user \) -print 2> /dev/null)" && [[ -n ${result} ]]
     }
 
     update_ownership() {


### PR DESCRIPTION
## Summary

Checking the ownership of only the mount point itself appears to be not enough.

Fixes zwift install error when using docker:

```text
wine: '/home/user/.wine' is not owned by you.
```

This is probably also the reason why the build from scratch workflow failed.

I remember that we discussed that this change was needed a while ago. And I thought it was actually already implemented. But I can't seem to find it in the git history, issues, discussions or pull requests.