### PR TITLE
Don't start an interactive shell when ZWIFT_FG is set

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -571,7 +571,8 @@ Set this option to a value to change the Zwift game resolution. For details on h
 ### `ZWIFT_FG`
 
 If set to `1`, launch the container in the foreground instead of the background. Use this option if you want to see the output
-of the scripts that run inside the container or if you need to wait for the container to finish to automatically perform a task.
+of the scripts that run inside the container, if you need to wait for the container to finish to automatically perform a task,
+or if you want to run Zwift with a 3rd party launcher (e.g. Steam).
 
 | Item              | Description                                   |
 |:------------------|:----------------------------------------------|

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -466,7 +466,6 @@ if [[ ${INTERACTIVE} -eq 1 ]]; then
     container_args+=(-it --entrypoint bash)
 elif [[ ${ZWIFT_FG} -eq 1 ]]; then
     container_env_vars+=(COLORED_OUTPUT="${COLORED_OUTPUT_SUPPORTED}")
-    container_args+=(-it)
 else
     container_env_vars+=(COLORED_OUTPUT="0")
     container_args+=(-d)


### PR DESCRIPTION
This is a regression that occurred a while ago, but I just noticed it because I was lazy and haven't updated `zwift.sh` in months. See #213 for the use-case (I also updated the docs to include my use-case :smile:).