### PR TITLE
ZWIFT_FG and interactive shell

### DIFF
--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -466,6 +466,7 @@ if [[ ${INTERACTIVE} -eq 1 ]]; then
     container_args+=(-it --entrypoint bash)
 elif [[ ${ZWIFT_FG} -eq 1 ]]; then
     container_env_vars+=(COLORED_OUTPUT="${INTERACTIVE_TERMINAL}")
+    [[ ${INTERACTIVE_TERMINAL} -eq 1 ]] && container_args+=(-it)
 else
     container_env_vars+=(COLORED_OUTPUT="0")
     container_args+=(-d)

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -17,7 +17,7 @@ readonly ZWIFT_HOME="/home/user/.wine/drive_c/Program Files (x86)/Zwift"
 readonly ZWIFT_DOCS="${WINE_USER_HOME}/AppData/Local/Zwift"
 
 if [[ -t 1 ]]; then
-    readonly COLORED_OUTPUT_SUPPORTED="1"
+    readonly INTERACTIVE_TERMINAL="1"
     readonly COLOR_WHITE="\033[0;37m"
     readonly COLOR_RED="\033[0;31m"
     readonly COLOR_GREEN="\033[0;32m"
@@ -29,7 +29,7 @@ if [[ -t 1 ]]; then
     readonly OVERWRITE_PREV_LINE="\033[1A\033[K"
     readonly OVERWRITE_CURRENT_LINE="\r\033[K"
 else
-    readonly COLORED_OUTPUT_SUPPORTED="0"
+    readonly INTERACTIVE_TERMINAL="0"
     readonly COLOR_WHITE=""
     readonly COLOR_RED=""
     readonly COLOR_GREEN=""
@@ -462,10 +462,10 @@ fi
 
 # Interactive mode and run in foreground/background
 if [[ ${INTERACTIVE} -eq 1 ]]; then
-    container_env_vars+=(COLORED_OUTPUT="${COLORED_OUTPUT_SUPPORTED}")
+    container_env_vars+=(COLORED_OUTPUT="${INTERACTIVE_TERMINAL}")
     container_args+=(-it --entrypoint bash)
 elif [[ ${ZWIFT_FG} -eq 1 ]]; then
-    container_env_vars+=(COLORED_OUTPUT="${COLORED_OUTPUT_SUPPORTED}")
+    container_env_vars+=(COLORED_OUTPUT="${INTERACTIVE_TERMINAL}")
 else
     container_env_vars+=(COLORED_OUTPUT="0")
     container_args+=(-d)


### PR DESCRIPTION
## Summary

See #342 for context.

When running zwift in the foreground (`ZWIF_FG=1`):

- Adding `-it` caused a regression as described in #342, so we removed it again.
- Without `-it` it's not possible to use for example `ctrl+c` to terminate zwift.

Can we do both? This PR only adds the `-it` flag when `ZWIFT_FG=1` if the zwift.sh script is running in an interactive terminal.

## Implementation

- We already check whether the zwift script is running in an interactive terminal using `[[ -t 1 ]]`.
- Based on that we enable or disable fancy messages.
- Set a flag `INTERACTIVE_TERMINAL=1` and use it to enable `-it` if `ZWIFT_FG=1`.

## Testing

@kschat Could you try if this works for your usecase?