### PR TITLE
Feature/wine-stability

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -70,16 +70,8 @@ msgbox() {
     local type="${1:?}" # Type: info, ok, warning, error, question, debug
     local msg="${2:?}"  # Message: the message to display
 
-    make_timestamp() {
-        if [[ ${VERBOSITY} -ge 2 ]]; then
-            printf '%(%T)T|' -1
-        else
-            printf ''
-        fi
-    }
-
-    local timestamp
-    timestamp="$(make_timestamp)"
+    local timestamp=""
+    [[ ${VERBOSITY} -ge 2 ]] && printf -v timestamp '%(%T)T|' -1
 
     case ${type} in
         info) [[ ${VERBOSITY} -ge 1 ]] && echo -e "${COLOR_BLUE}[${timestamp}*] ${msg}${RESET_STYLE}" ;;

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -128,6 +128,9 @@ podman build -t zwift:dev .
 
 # Or use the build script
 ./build-image.sh
+
+# Or only update the scripts if you already built the imgage
+./update-image.sh
 ```
 
 ## Testing Changes

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -33,6 +33,7 @@ ARG WINETRICKS_VERSION=20240105
 
 # Install prerequisites
 # - ca-certificates for wget and curl
+# - cabextract for winetricks
 # - curl used in zwift authentication script
 # - gamemode for freedesktop screensaver inhibit
 # - gosu for invoking scripts in entrypoint
@@ -47,6 +48,7 @@ RUN dpkg --add-architecture i386 \
  && DEBIAN_FRONTEND="noninteractive" apt-get update \
  && DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
         ca-certificates \
+        cabextract \
         curl \
         gamemode \
         gosu \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -75,6 +75,9 @@ RUN dpkg --add-architecture i386 \
  && rm -rf /var/lib/apt/lists/*
 
 # Install wine and winetricks (including recommends, which appear to be required)
+# Download wine mono and gecko installers
+# - Place them where wine can find them, this avoids the confirmation dialog when booting wine
+# - Avoid WINEDLLOVERRIDES="mscoree,mshtml=" wineboot -u workaround
 # hadolint ignore=DL3015
 RUN wget -qO /etc/apt/trusted.gpg.d/winehq.asc https://dl.winehq.org/wine-builds/winehq.key \
  && echo "deb https://dl.winehq.org/wine-builds/debian/ ${DEBIAN_VERSION} main" > /etc/apt/sources.list.d/winehq.list \
@@ -86,20 +89,18 @@ RUN wget -qO /etc/apt/trusted.gpg.d/winehq.asc https://dl.winehq.org/wine-builds
         winehq-${WINE_BRANCH}${WINE_VERSION} \
  && rm -rf /var/lib/apt/lists/* \
  && wget -qO /usr/local/bin/winetricks https://raw.githubusercontent.com/Winetricks/winetricks/${WINETRICKS_VERSION}/src/winetricks \
- && chmod +x /usr/local/bin/winetricks
+ && chmod +x /usr/local/bin/winetricks \
+ && mkdir -p /opt/wine/mono /opt/wine/gecko \
+ && wget -qO /opt/wine/mono/wine-mono-${MONO_VERSION}-x86.msi https://dl.winehq.org/wine/wine-mono/${MONO_VERSION}/wine-mono-${MONO_VERSION}-x86.msi \
+ && wget -qO /opt/wine/gecko/wine-gecko-${GECKO_VERSION}-x86_64.msi https://dl.winehq.org/wine/wine-gecko/${GECKO_VERSION}/wine-gecko-${GECKO_VERSION}-x86_64.msi
 
 # Create passwordless user and make nvidia libraries discoverable
 RUN adduser --disabled-password --gecos '' user \
  && adduser user sudo \
  && echo '%SUDO ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
+ && chown -R user:user /opt/wine \
  && echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf \
  && echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
-
-# Download wine mono and gecko installers
-# Place them where wine can find them, this avoids the confirmation dialog when booting wine
-# Avoid WINEDLLOVERRIDES="mscoree,mshtml=" wineboot -u workaround
-ADD --chown=user:user https://dl.winehq.org/wine/wine-mono/${MONO_VERSION}/wine-mono-${MONO_VERSION}-x86.msi /opt/wine/mono/
-ADD --chown=user:user https://dl.winehq.org/wine/wine-gecko/${GECKO_VERSION}/wine-gecko-${GECKO_VERSION}-x86_64.msi /opt/wine/gecko/
 
 # Required for non-glvnd setups
 ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib/i386-linux-gnu:/usr/local/nvidia/lib:/usr/local/nvidia/lib64

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -38,8 +38,11 @@ ARG DEBIAN_VERSION
 ARG WINE_BRANCH="devel"
 ARG WINE_VERSION="=9.9~${DEBIAN_VERSION}-1"
 ARG WINETRICKS_VERSION=20260125
+ARG WINETRICKS_CHECKSUM=431f82fc74000e6c864409f1d8fb495d696c03928808e3e8acffc45179312a7b
 ARG MONO_VERSION=9.1.0
+ARG MONO_CHECKSUM=8a0a1e6837b494df49927e5d759b1c6908e89b8a2f8e3ad025e1c2881882476e
 ARG GECKO_VERSION=2.47.4
+ARG GECKO_CHECKSUM=e590b7d988a32d6aa4cf1d8aa3aa3d33766fdd4cf4c89c2dcc2095ecb28d066f
 
 # Install prerequisites
 # - ca-certificates for wget and curl
@@ -74,10 +77,7 @@ RUN dpkg --add-architecture i386 \
         xdg-utils \
  && rm -rf /var/lib/apt/lists/*
 
-# Install wine and winetricks (including recommends, which appear to be required)
-# Download wine mono and gecko installers
-# - Place them where wine can find them, this avoids the confirmation dialog when booting wine
-# - Avoid WINEDLLOVERRIDES="mscoree,mshtml=" wineboot -u workaround
+# Install wine (including recommends, which appear to be required)
 # hadolint ignore=DL3015
 RUN wget -qO /etc/apt/trusted.gpg.d/winehq.asc https://dl.winehq.org/wine-builds/winehq.key \
  && echo "deb https://dl.winehq.org/wine-builds/debian/ ${DEBIAN_VERSION} main" > /etc/apt/sources.list.d/winehq.list \
@@ -87,12 +87,16 @@ RUN wget -qO /etc/apt/trusted.gpg.d/winehq.asc https://dl.winehq.org/wine-builds
         wine-${WINE_BRANCH}-amd64${WINE_VERSION} \
         wine-${WINE_BRANCH}-i386${WINE_VERSION} \
         winehq-${WINE_BRANCH}${WINE_VERSION} \
- && rm -rf /var/lib/apt/lists/* \
- && wget -qO /usr/local/bin/winetricks https://raw.githubusercontent.com/Winetricks/winetricks/${WINETRICKS_VERSION}/src/winetricks \
- && chmod +x /usr/local/bin/winetricks \
- && mkdir -p /opt/wine/mono /opt/wine/gecko \
- && wget -qO /opt/wine/mono/wine-mono-${MONO_VERSION}-x86.msi https://dl.winehq.org/wine/wine-mono/${MONO_VERSION}/wine-mono-${MONO_VERSION}-x86.msi \
- && wget -qO /opt/wine/gecko/wine-gecko-${GECKO_VERSION}-x86_64.msi https://dl.winehq.org/wine/wine-gecko/${GECKO_VERSION}/wine-gecko-${GECKO_VERSION}-x86_64.msi
+ && rm -rf /var/lib/apt/lists/*
+
+# Download winetricks
+ADD --checksum=sha256:${WINETRICKS_CHECKSUM} --chmod=755 https://raw.githubusercontent.com/Winetricks/winetricks/${WINETRICKS_VERSION}/src/winetricks /usr/local/bin/
+
+# Download wine mono and gecko installers
+# - Installing mono and gecko fixes wine .net framework compilation errors
+# - Place them where wine can find them, this avoids the confirmation dialog when booting wine
+ADD --checksum=sha256:${MONO_CHECKSUM} https://dl.winehq.org/wine/wine-mono/${MONO_VERSION}/wine-mono-${MONO_VERSION}-x86.msi /opt/wine/mono/
+ADD --checksum=sha256:${GECKO_CHECKSUM} https://dl.winehq.org/wine/wine-gecko/${GECKO_VERSION}/wine-gecko-${GECKO_VERSION}-x86_64.msi /opt/wine/gecko/
 
 # Create passwordless user and make nvidia libraries discoverable
 RUN adduser --disabled-password --gecos '' user \
@@ -123,6 +127,6 @@ COPY --chmod=755 entrypoint.sh /bin/entrypoint
 COPY --chmod=755 update_zwift.sh /bin/update_zwift.sh
 COPY --chmod=755 run_zwift.sh /bin/run_zwift.sh
 COPY --chmod=755 zwift-auth.sh /bin/zwift-auth
-COPY --chmod=755 --from=build-runfromprocess /usr/src/target/x86_64-pc-windows-gnu/release/runfromprocess-rs.exe /bin/runfromprocess-rs.exe
+COPY --from=build-runfromprocess /usr/src/target/x86_64-pc-windows-gnu/release/runfromprocess-rs.exe /bin/runfromprocess-rs.exe
 
 ENTRYPOINT ["entrypoint"]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -64,6 +64,8 @@ RUN dpkg --add-architecture i386 \
         gosu \
         libegl1 \
         libgl1 \
+        libgamemode0.i386 \
+        libgamemodeauto0.i386 \
         libvulkan1 \
         procps \
         sudo \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -18,35 +18,6 @@ WORKDIR /usr/src
 ADD https://github.com/quietvoid/runfromprocess-rs.git#${RUNFROMPROCESS_VERSION} .
 RUN cargo build --target x86_64-pc-windows-gnu --release
 
-FROM debian:${DEBIAN_VERSION}-slim AS build-wine-mono-gecko
-
-# Mono
-# - https://gitlab.winehq.org/wine/wine/-/wikis/Wine-Mono
-# - version depends on wine version!
-# Gecko
-# - https://gitlab.winehq.org/wine/wine/-/wikis/Gecko
-# - version depends on wine version!
-ARG MONO_VERSION=9.1.0
-ARG MONO_CHECKSUM=601169d0203b291fbfd946b356a9538855e01de22abd470ded73baf312c88767
-ARG GECKO_VERSION=2.47.4
-ARG GECKO_CHECKSUM=fd88fc7e537d058d7a8abf0c1ebc90c574892a466de86706a26d254710a82814
-
-# Install prerequisites
-# - xz-utils to extract .tar.xz archives
-RUN DEBIAN_FRONTEND="noninteractive" apt-get update \
- && DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
-        xz-utils \
- && rm -rf /var/lib/apt/lists/*
-
-# Download wine mono and gecko
-ADD --checksum=sha256:${MONO_CHECKSUM} https://dl.winehq.org/wine/wine-mono/${MONO_VERSION}/wine-mono-${MONO_VERSION}-x86.tar.xz /tmp/
-ADD --checksum=sha256:${GECKO_CHECKSUM} https://dl.winehq.org/wine/wine-gecko/${GECKO_VERSION}/wine-gecko-${GECKO_VERSION}-x86_64.tar.xz /tmp/
-
-# Extract wine mono and gecko
-RUN mkdir -p /opt/wine/mono /opt/wine/gecko \
- && tar -xJ -C /opt/wine/mono/ -f /tmp/wine-mono-${MONO_VERSION}-x86.tar.xz \
- && tar -xJ -C /opt/wine/gecko/ -f /tmp/wine-gecko-${GECKO_VERSION}-x86_64.tar.xz
-
 FROM debian:${DEBIAN_VERSION}-slim AS wine-base
 
 # Wine
@@ -56,8 +27,14 @@ FROM debian:${DEBIAN_VERSION}-slim AS wine-base
 # Winetricks
 # - 20260125 : webview2 in zwift launcher works
 # - 20240105 : first version used in this Dockerfile
+# Mono
+# - https://gitlab.winehq.org/wine/wine/-/wikis/Wine-Mono
+# - version depends on wine version!
+# Gecko
+# - https://gitlab.winehq.org/wine/wine/-/wikis/Gecko
+# - version depends on wine version!
 ARG DEBIAN_VERSION
-ARG WINE_BRANCH=devel
+ARG WINE_BRANCH="devel"
 ARG WINE_VERSION="=9.9~${DEBIAN_VERSION}-1"
 ARG WINETRICKS_VERSION=20260125
 ARG WINETRICKS_CHECKSUM=431f82fc74000e6c864409f1d8fb495d696c03928808e3e8acffc45179312a7b
@@ -107,10 +84,6 @@ RUN wget -qO /etc/apt/trusted.gpg.d/winehq.asc https://dl.winehq.org/wine-builds
 
 # Download winetricks
 ADD --checksum=sha256:${WINETRICKS_CHECKSUM} --chmod=755 https://raw.githubusercontent.com/Winetricks/winetricks/${WINETRICKS_VERSION}/src/winetricks /usr/local/bin/
-
-# Install wine mono and gecko (instead of dotnet framework)
-COPY --from=build-wine-mono-gecko /opt/wine/mono/ /usr/share/wine/mono/
-COPY --from=build-wine-mono-gecko /opt/wine/gecko/ /usr/share/wine/gecko/
 
 # Create passwordless user and make nvidia libraries discoverable
 RUN adduser --disabled-password --gecos '' user \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,6 +1,6 @@
 ARG DEBIAN_VERSION=trixie
 
-FROM rust:1.90-slim AS build-runfromprocess
+FROM rust:1.94.1-slim AS build-runfromprocess
 
 # Install prerequisites
 # - mingw to cross-compile for windows

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -52,7 +52,6 @@ ARG GECKO_CHECKSUM=e590b7d988a32d6aa4cf1d8aa3aa3d33766fdd4cf4c89c2dcc2095ecb28d0
 # - libegl1 and libgl1 for GL library
 # - libvulkan1 for vulkan loader library
 # - procps for pgrep
-# - sudo for normal user installation
 # - wget for downloading winehq key
 # - winbind for ntml_auth required by zwift/wine
 # - xdg-utils seems to be a dependency of wayland
@@ -70,7 +69,6 @@ RUN dpkg --add-architecture i386 \
         libgamemodeauto0.i386 \
         libvulkan1 \
         procps \
-        sudo \
         wget \
         winbind \
         xdg-utils \
@@ -99,8 +97,6 @@ ADD --checksum=sha256:${GECKO_CHECKSUM} https://dl.winehq.org/wine/wine-gecko/${
 
 # Create passwordless user and make nvidia libraries discoverable
 RUN adduser --disabled-password --gecos '' user \
- && adduser user sudo \
- && echo '%SUDO ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
  && echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf \
  && echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -2,22 +2,21 @@ ARG DEBIAN_VERSION=trixie
 
 FROM rust:1.94.1-slim AS build-runfromprocess
 
+ARG RUNFROMPROCESS_VERSION=a3d003c07d1bd11ff93c4cac96d2c3aa5deb8471
+
 # Install prerequisites
 # - mingw to cross-compile for windows
-# - git to fetch runfromprocess source code
 # - rust cross-compiler for windows
 RUN DEBIAN_FRONTEND="noninteractive" apt-get update \
  && DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
         g++-mingw-w64-x86-64 \
-        git \
  && rm -rf /var/lib/apt/lists/* \
  && rustup target add x86_64-pc-windows-gnu
 
 # Build runfromprocess
 WORKDIR /usr/src
-RUN git clone https://github.com/quietvoid/runfromprocess-rs . \
- && git checkout d8754035b1b8a38f96ec6806a772a944ef5396c0 \
- && cargo build --target x86_64-pc-windows-gnu --release
+ADD https://github.com/quietvoid/runfromprocess-rs.git#${RUNFROMPROCESS_VERSION} .
+RUN cargo build --target x86_64-pc-windows-gnu --release
 
 FROM debian:${DEBIAN_VERSION}-slim AS wine-base
 
@@ -102,7 +101,6 @@ ADD --checksum=sha256:${GECKO_CHECKSUM} https://dl.winehq.org/wine/wine-gecko/${
 RUN adduser --disabled-password --gecos '' user \
  && adduser user sudo \
  && echo '%SUDO ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
- && chown -R user:user /opt/wine \
  && echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf \
  && echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,6 +1,6 @@
 ARG DEBIAN_VERSION=trixie
 
-FROM rust:1.94.1-slim AS build-runfromprocess
+FROM rust:1.95.0-slim-trixie AS build-runfromprocess
 
 ARG RUNFROMPROCESS_VERSION=a3d003c07d1bd11ff93c4cac96d2c3aa5deb8471
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -26,10 +26,18 @@ FROM debian:${DEBIAN_VERSION}-slim AS wine-base
 # For Specific version fix add WINE_VERSION,
 # make sure to add "=" to the start, comment out for latest
 #    WINE_VERSION="=9.9~bookworm-1"
+# Mono
+# - https://gitlab.winehq.org/wine/wine/-/wikis/Wine-Mono
+# - version depends on wine version!
+# Gecko
+# - https://gitlab.winehq.org/wine/wine/-/wikis/Gecko
+# - version depends on wine version!
 ARG DEBIAN_VERSION
 ARG WINE_BRANCH="devel"
 ARG WINE_VERSION="=9.9~${DEBIAN_VERSION}-1"
 ARG WINETRICKS_VERSION=20240105
+ARG MONO_VERSION=9.1.0
+ARG GECKO_VERSION=2.47.4
 
 # Install prerequisites
 # - ca-certificates for wget and curl
@@ -82,6 +90,12 @@ RUN adduser --disabled-password --gecos '' user \
  && echo '%SUDO ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
  && echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf \
  && echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
+
+# Download wine mono and gecko installers
+# Place them where wine can find them, this avoids the confirmation dialog when booting wine
+# Avoid WINEDLLOVERRIDES="mscoree,mshtml=" wineboot -u workaround
+ADD --chown=user:user https://dl.winehq.org/wine/wine-mono/${MONO_VERSION}/wine-mono-${MONO_VERSION}-x86.msi /opt/wine/mono/
+ADD --chown=user:user https://dl.winehq.org/wine/wine-gecko/${GECKO_VERSION}/wine-gecko-${GECKO_VERSION}-x86_64.msi /opt/wine/gecko/
 
 # Required for non-glvnd setups
 ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib/i386-linux-gnu:/usr/local/nvidia/lib:/usr/local/nvidia/lib64

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -6,8 +6,8 @@ FROM rust:1.94.1-slim AS build-runfromprocess
 # - mingw to cross-compile for windows
 # - git to fetch runfromprocess source code
 # - rust cross-compiler for windows
-RUN apt-get update \
- && apt-get install --no-install-recommends -y \
+RUN DEBIAN_FRONTEND="noninteractive" apt-get update \
+ && DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
         g++-mingw-w64-x86-64 \
         git \
  && rm -rf /var/lib/apt/lists/* \
@@ -44,8 +44,8 @@ ARG WINETRICKS_VERSION=20240105
 # - winbind for ntml_auth required by zwift/wine
 # - xdg-utils seems to be a dependency of wayland
 RUN dpkg --add-architecture i386 \
- && apt-get update \
- && apt-get install --no-install-recommends -y \
+ && DEBIAN_FRONTEND="noninteractive" apt-get update \
+ && DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
         ca-certificates \
         curl \
         gamemode \
@@ -64,8 +64,8 @@ RUN dpkg --add-architecture i386 \
 # hadolint ignore=DL3015
 RUN wget -qO /etc/apt/trusted.gpg.d/winehq.asc https://dl.winehq.org/wine-builds/winehq.key \
  && echo "deb https://dl.winehq.org/wine-builds/debian/ ${DEBIAN_VERSION} main" > /etc/apt/sources.list.d/winehq.list \
- && apt-get update \
- && apt-get install -y \
+ && DEBIAN_FRONTEND="noninteractive" apt-get update \
+ && DEBIAN_FRONTEND="noninteractive" apt-get install -y \
         wine-${WINE_BRANCH}${WINE_VERSION} \
         wine-${WINE_BRANCH}-amd64${WINE_VERSION} \
         wine-${WINE_BRANCH}-i386${WINE_VERSION} \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -27,12 +27,6 @@ FROM debian:${DEBIAN_VERSION}-slim AS wine-base
 # Winetricks
 # - 20260125 : webview2 in zwift launcher works
 # - 20240105 : first version used in this Dockerfile
-# Mono
-# - https://gitlab.winehq.org/wine/wine/-/wikis/Wine-Mono
-# - version depends on wine version!
-# Gecko
-# - https://gitlab.winehq.org/wine/wine/-/wikis/Gecko
-# - version depends on wine version!
 ARG DEBIAN_VERSION
 ARG WINE_BRANCH="devel"
 ARG WINE_VERSION="=9.9~${DEBIAN_VERSION}-1"

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -18,6 +18,35 @@ WORKDIR /usr/src
 ADD https://github.com/quietvoid/runfromprocess-rs.git#${RUNFROMPROCESS_VERSION} .
 RUN cargo build --target x86_64-pc-windows-gnu --release
 
+FROM debian:${DEBIAN_VERSION}-slim AS build-wine-mono-gecko
+
+# Mono
+# - https://gitlab.winehq.org/wine/wine/-/wikis/Wine-Mono
+# - version depends on wine version!
+# Gecko
+# - https://gitlab.winehq.org/wine/wine/-/wikis/Gecko
+# - version depends on wine version!
+ARG MONO_VERSION=9.1.0
+ARG MONO_CHECKSUM=601169d0203b291fbfd946b356a9538855e01de22abd470ded73baf312c88767
+ARG GECKO_VERSION=2.47.4
+ARG GECKO_CHECKSUM=fd88fc7e537d058d7a8abf0c1ebc90c574892a466de86706a26d254710a82814
+
+# Install prerequisites
+# - xz-utils to extract .tar.xz archives
+RUN DEBIAN_FRONTEND="noninteractive" apt-get update \
+ && DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
+        xz-utils \
+ && rm -rf /var/lib/apt/lists/*
+
+# Download wine mono and gecko
+ADD --checksum=sha256:${MONO_CHECKSUM} https://dl.winehq.org/wine/wine-mono/${MONO_VERSION}/wine-mono-${MONO_VERSION}-x86.tar.xz /tmp/
+ADD --checksum=sha256:${GECKO_CHECKSUM} https://dl.winehq.org/wine/wine-gecko/${GECKO_VERSION}/wine-gecko-${GECKO_VERSION}-x86_64.tar.xz /tmp/
+
+# Extract wine mono and gecko
+RUN mkdir -p /opt/wine/mono /opt/wine/gecko \
+ && tar -xJ -C /opt/wine/mono/ -f /tmp/wine-mono-${MONO_VERSION}-x86.tar.xz \
+ && tar -xJ -C /opt/wine/gecko/ -f /tmp/wine-gecko-${GECKO_VERSION}-x86_64.tar.xz
+
 FROM debian:${DEBIAN_VERSION}-slim AS wine-base
 
 # Wine
@@ -27,21 +56,11 @@ FROM debian:${DEBIAN_VERSION}-slim AS wine-base
 # Winetricks
 # - 20260125 : webview2 in zwift launcher works
 # - 20240105 : first version used in this Dockerfile
-# Mono
-# - https://gitlab.winehq.org/wine/wine/-/wikis/Wine-Mono
-# - version depends on wine version!
-# Gecko
-# - https://gitlab.winehq.org/wine/wine/-/wikis/Gecko
-# - version depends on wine version!
 ARG DEBIAN_VERSION
-ARG WINE_BRANCH="devel"
+ARG WINE_BRANCH=devel
 ARG WINE_VERSION="=9.9~${DEBIAN_VERSION}-1"
 ARG WINETRICKS_VERSION=20260125
 ARG WINETRICKS_CHECKSUM=431f82fc74000e6c864409f1d8fb495d696c03928808e3e8acffc45179312a7b
-ARG MONO_VERSION=9.1.0
-ARG MONO_CHECKSUM=8a0a1e6837b494df49927e5d759b1c6908e89b8a2f8e3ad025e1c2881882476e
-ARG GECKO_VERSION=2.47.4
-ARG GECKO_CHECKSUM=e590b7d988a32d6aa4cf1d8aa3aa3d33766fdd4cf4c89c2dcc2095ecb28d066f
 
 # Install prerequisites
 # - ca-certificates for wget and curl
@@ -89,11 +108,9 @@ RUN wget -qO /etc/apt/trusted.gpg.d/winehq.asc https://dl.winehq.org/wine-builds
 # Download winetricks
 ADD --checksum=sha256:${WINETRICKS_CHECKSUM} --chmod=755 https://raw.githubusercontent.com/Winetricks/winetricks/${WINETRICKS_VERSION}/src/winetricks /usr/local/bin/
 
-# Download wine mono and gecko installers
-# - Installing mono and gecko fixes wine .net framework compilation errors
-# - Place them where wine can find them, this avoids the confirmation dialog when booting wine
-ADD --checksum=sha256:${MONO_CHECKSUM} https://dl.winehq.org/wine/wine-mono/${MONO_VERSION}/wine-mono-${MONO_VERSION}-x86.msi /opt/wine/mono/
-ADD --checksum=sha256:${GECKO_CHECKSUM} https://dl.winehq.org/wine/wine-gecko/${GECKO_VERSION}/wine-gecko-${GECKO_VERSION}-x86_64.msi /opt/wine/gecko/
+# Install wine mono and gecko (instead of dotnet framework)
+COPY --from=build-wine-mono-gecko /opt/wine/mono/ /usr/share/wine/mono/
+COPY --from=build-wine-mono-gecko /opt/wine/gecko/ /usr/share/wine/gecko/
 
 # Create passwordless user and make nvidia libraries discoverable
 RUN adduser --disabled-password --gecos '' user \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -21,11 +21,13 @@ RUN git clone https://github.com/quietvoid/runfromprocess-rs . \
 
 FROM debian:${DEBIAN_VERSION}-slim AS wine-base
 
-# As at May 2024 Wayland Native works wine 9.9 or later:
-#    WINE_BRANCH="devel"
-# For Specific version fix add WINE_VERSION,
-# make sure to add "=" to the start, comment out for latest
-#    WINE_VERSION="=9.9~bookworm-1"
+# Wine
+# - 11.0     : support 32-bit applications through wow64
+# - 10.17    : default to egl for opengl in x11
+# - 9.9      : support native wayland
+# Winetricks
+# - 20260125 : webview2 in zwift launcher works
+# - 20240105 : first version used in this Dockerfile
 # Mono
 # - https://gitlab.winehq.org/wine/wine/-/wikis/Wine-Mono
 # - version depends on wine version!
@@ -35,7 +37,7 @@ FROM debian:${DEBIAN_VERSION}-slim AS wine-base
 ARG DEBIAN_VERSION
 ARG WINE_BRANCH="devel"
 ARG WINE_VERSION="=9.9~${DEBIAN_VERSION}-1"
-ARG WINETRICKS_VERSION=20240105
+ARG WINETRICKS_VERSION=20260125
 ARG MONO_VERSION=9.1.0
 ARG GECKO_VERSION=2.47.4
 

--- a/src/build-image.sh
+++ b/src/build-image.sh
@@ -32,16 +32,8 @@ msgbox() {
     local type="${1:?}" # Type: info, ok, warning, error, debug
     local msg="${2:?}"  # Message: the message to display
 
-    make_timestamp() {
-        if [[ ${VERBOSITY} -ge 2 ]]; then
-            printf '%(%T)T|' -1
-        else
-            printf ''
-        fi
-    }
-
-    local timestamp
-    timestamp="$(make_timestamp)"
+    local timestamp=""
+    [[ ${VERBOSITY} -ge 2 ]] && printf -v timestamp '%(%T)T|' -1
 
     case ${type} in
         info) [[ ${VERBOSITY} -ge 1 ]] && echo -e "${COLOR_BLUE}[${timestamp}*] ${msg}${RESET_STYLE}" ;;

--- a/src/build-image.sh
+++ b/src/build-image.sh
@@ -180,7 +180,7 @@ msgbox info "Building image ${IMAGE}"
 if ${CONTAINER_TOOL} build --force-rm -t "${BUILD_NAME}" "${SCRIPT_DIR}"; then
     msgbox ok "Successfully built image ${IMAGE}"
 else
-    msgbox error "Failed to build image"
+    msgbox error "Failed to build image! 😭"
     exit 1
 fi
 
@@ -188,7 +188,7 @@ msgbox info "Launching temporary container to install Zwift"
 if ${CONTAINER_TOOL} run "${container_args[@]}" "${IMAGE}:latest" "${@}"; then
     msgbox ok "Successfully installed Zwift in container"
 else
-    msgbox error "Failed to start container"
+    msgbox error "Failed to install Zwift in container! 😭"
     exit 1
 fi
 
@@ -196,11 +196,13 @@ msgbox info "Updating image with changes from temporary container"
 if ${CONTAINER_TOOL} commit zwift "${BUILD_NAME}:latest"; then
     msgbox ok "Tagged Zwift container as ${IMAGE}:latest"
 else
-    msgbox error "Failed to commit container changes to image"
+    msgbox error "Failed to commit container changes to image! 😭"
     exit 1
 fi
 
 cleanup
+
+msgbox ok "Successfully created Zwift container image ${IMAGE}:latest! 🥳"
 
 ########################
 ##### Launch Zwift #####

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -35,16 +35,8 @@ msgbox() {
     local type="${1:?}" # Type: info, ok, warning, error, debug
     local msg="${2:?}"  # Message: the message to display
 
-    make_timestamp() {
-        if [[ ${VERBOSITY} -ge 2 ]]; then
-            printf '%(%T)T|' -1
-        else
-            printf ''
-        fi
-    }
-
-    local timestamp
-    timestamp="$(make_timestamp)"
+    local timestamp=""
+    [[ ${VERBOSITY} -ge 2 ]] && printf -v timestamp '%(%T)T|' -1
 
     case ${type} in
         info) [[ ${VERBOSITY} -ge 1 ]] && echo -e "${COLOR_BLUE}[${CONTAINER_TOOL}|${timestamp}*] ${msg}${RESET_STYLE}" ;;

--- a/src/run_zwift.sh
+++ b/src/run_zwift.sh
@@ -52,8 +52,7 @@ msgbox() {
 
 wine_task_info() {
     local task_name="${1:?}"
-    local filter="${2:-IMAGENAME}"
-    wine tasklist /fo list /fi "${filter} eq ${task_name}"
+    wine tasklist /fo list /fi "IMAGENAME eq ${task_name}"
 }
 
 wine_task_pid() {
@@ -66,12 +65,7 @@ is_wine_task_running() {
     [[ -n $(wine_task_info "${task_name}" || true) ]]
 }
 
-is_wine_window_open() {
-    local window_title="${1:?}"
-    [[ -n $(wine_task_info "${window_title}" WINDOWTITLE || true) ]]
-}
-
-kill_wine_task() {
+kill_wine_tasks() {
     for task in "${@}"; do
         msgbox debug "Killing wine task '${task}'"
         wine taskkill /f /im "${task}" > /dev/null 2>&1 || true
@@ -144,6 +138,19 @@ fi
 ##################################
 ##### Start Zwift using wine #####
 
+# The Zwift launcher is not fully functional in wine:
+# - It cannot show the login page (1)
+# - It cannot launch Zwift (2)
+# - If Zwift itself is started independently, it will automatically start the launcher (3)
+# Workaround for (1):
+# 1. Manually invoke the Zwift API to login and obtain an authentication token using the zwift-auth.sh script
+# 2. Pass the authentication token to ZwiftApp.exe using the --token=... argument
+# Workaround for (2) and (3):
+# 1. Start the launcher ZwiftLauncher.exe in the background using SilentLaunch
+# 2. Obtain the launcher wine process id
+# 3. Use runfromprocess to launch ZwiftApp.exe with the launcher process as parent
+# 4. Kill ZwiftLauncher.exe
+
 msgbox info "Starting Zwift launcher using wine"
 
 if ! wine start ZwiftLauncher.exe SilentLaunch; then
@@ -167,22 +174,8 @@ if ! "${wine_cmd[@]}"; then
     exit 1
 fi
 
-# Wait for Zwift to start
-counter=1
-max_iterations=10
-while ! is_wine_window_open Zwift && [[ ${counter} -le ${max_iterations} ]]; do
-    msgbox info "Waiting for Zwift to start... (${counter}/${max_iterations})"
-    sleep 0.5
-    ((counter++))
-done
-if ! is_wine_window_open Zwift; then
-    msgbox error "Zwift has not started yet, giving up!"
-    exit 1
-fi
-
-# Kill launcher as soon as possible to prevent it from updating Zwift
 msgbox info "Killing Zwift launcher and background tasks"
-kill_wine_task ZwiftLauncher.exe ZwiftWindowsCrashHandler.exe MicrosoftEdgeUpdate.exe
+kill_wine_tasks ZwiftLauncher.exe ZwiftWindowsCrashHandler.exe MicrosoftEdgeUpdate.exe
 
 msgbox ok "Zwift started using wine"
 

--- a/src/run_zwift.sh
+++ b/src/run_zwift.sh
@@ -58,8 +58,32 @@ msgbox() {
     esac
 }
 
+wine_task_info() {
+    local task="${1:?}"
+    wine tasklist /fo list /fi "IMAGENAME eq ${task}"
+}
+
+wine_task_pid() {
+    wine_task_info "${@}" | grep -m1 -Po '^PID:[\t ]*\K[0-9]+'
+}
+
+is_wine_task_running() {
+    [[ -n $(wine_task_info "${@}" || true) ]]
+}
+
+kill_wine_task() {
+    for task in "${@}"; do
+        msgbox debug "Killing wine task '${task}'"
+        wine taskkill /f /im "${task}" > /dev/null 2>&1 || true
+    done
+}
+
 ###########################
 ##### Configure Zwift #####
+
+# Create array for zwift arguments
+declare -a zwift_args
+zwift_args=()
 
 if [[ ! -d ${ZWIFT_HOME} ]] || ! cd "${ZWIFT_HOME}"; then
     msgbox error "Directory ${ZWIFT_HOME} does not exist. Has Zwift been installed?"
@@ -79,24 +103,46 @@ if [[ -n ${ZWIFT_OVERRIDE_RESOLUTION} ]]; then
     fi
 fi
 
-#########################################
-##### Automatically cleanup on exit #####
-
-cleanup_invoked=0
-cleanup() {
-    if [[ ${cleanup_invoked} -ne 1 ]]; then
-        msgbox info "Killing unnecessary applications"
-        pkill ZwiftLauncher || true
-        pkill ZwiftWindowsCra || true
-        pkill -f MicrosoftEdgeUpdate || true
-        cleanup_invoked=1
+if [[ -n ${ZWIFT_USERNAME} ]] && [[ -n ${ZWIFT_PASSWORD} ]]; then
+    msgbox info "Authenticating with Zwift"
+    if auth_token="$(zwift-auth)"; then
+        zwift_args+=(--token="${auth_token}")
+    else
+        msgbox warning "Authentication failed, manual login will be required"
     fi
+fi
+
+######################################################
+##### Start (and automatically stop) wine server #####
+
+cleanup() {
+    msgbox info "Stopping wine server"
+    wineserver -k || true
 }
 
 trap cleanup EXIT
 
-###########################################
-##### Start Zwift Launcher using wine #####
+msgbox info "Launching wine server"
+
+declare -a wineserver_cmd
+wineserver_cmd=(wineserver)
+
+if [[ ${ZWIFT_NO_GAMEMODE} -eq 1 ]]; then
+    msgbox warning "Not using gamemode"
+else
+    msgbox info "Using gamemode"
+    wineserver_cmd=(/usr/games/gamemoderun "${wineserver_cmd[@]}")
+fi
+
+if "${wineserver_cmd[@]}"; then
+    msgbox ok "Launched wine server"
+else
+    msgbox error "Failed to launch wine server!"
+    exit 1
+fi
+
+##################################
+##### Start Zwift using wine #####
 
 msgbox info "Starting Zwift launcher using wine"
 
@@ -105,64 +151,51 @@ if ! wine start ZwiftLauncher.exe SilentLaunch; then
     exit 1
 fi
 
-if ! launcher_pid_hex="$(winedbg --command "info proc" | grep -P "ZwiftLauncher.exe" | grep -oP "^\s\K.+?(?=\s)")"; then
+if ! launcher_pid="$(wine_task_pid ZwiftLauncher.exe)"; then
     msgbox error "Unable to get launcher process id. Did it crash?"
     exit 1
 fi
 
 msgbox ok "Zwift launcher started using wine"
-
-launcher_pid="$((16#${launcher_pid_hex}))"
-
-##################################
-##### Start Zwift using wine #####
+msgbox info "Starting Zwift using wine"
 
 declare -a wine_cmd
-wine_cmd=(wine start /exec /bin/runfromprocess-rs.exe "${launcher_pid}" ZwiftApp.exe)
+wine_cmd=(wine start /exec /bin/runfromprocess-rs.exe "${launcher_pid}" ZwiftApp.exe "${zwift_args[@]}")
 
-if [[ -n ${ZWIFT_USERNAME} ]] && [[ -n ${ZWIFT_PASSWORD} ]]; then
-    msgbox info "Authenticating with Zwift"
-    if token="$(zwift-auth)"; then
-        wine_cmd+=(--token="${token}")
-    else
-        msgbox warning "Authentication failed, manual login will be required"
-    fi
-fi
-
-msgbox info "Starting Zwift using wine"
 if ! "${wine_cmd[@]}"; then
     msgbox error "Failed to start Zwift using wine!"
     exit 1
 fi
 
-# important, without this sleep Zwift gets stuck in the launcher!
+# Important, without this sleep Zwift gets stuck in the launcher!
 for i in $(seq 3 -1 1); do
     msgbox info "Waiting for Zwift to start... (${i})"
     sleep 1
 done
-if ! pgrep -f ZwiftApp.exe > /dev/null 2>&1; then
-    msgbox error "Zwift has not yet started, giving up!"
+
+if ! is_wine_task_running ZwiftApp.exe; then
+    msgbox error "Zwift has not started yet, giving up!"
     exit 1
 fi
+
+# If launcher crashed, ZwiftApp.exe starts but does not do anything
+if ! is_wine_task_running ZwiftLauncher.exe; then
+    msgbox error "Zwift launcher exited unexpectedly. Did it crash?"
+    exit 1
+fi
+
+# Kill launcher as soon as possible to prevent it from updating Zwift
+msgbox info "Killing Zwift launcher and background tasks"
+kill_wine_task ZwiftLauncher.exe ZwiftWindowsCrashHandler.exe MicrosoftEdgeUpdate.exe
 
 msgbox ok "Zwift started using wine"
 
-#############################
-##### Start wine server #####
+##################################
+##### Wait for Zwift to exit #####
 
-cleanup # important, wine server will not stop if launcher etc keep running
+while is_wine_task_running ZwiftApp.exe; do
+    msgbox debug "Waiting for Zwift to exit..."
+    sleep 5
+done
 
-declare -a wineserver_cmd
-wineserver_cmd=(wineserver -w)
-
-if [[ ${ZWIFT_NO_GAMEMODE} -ne 1 ]]; then
-    wineserver_cmd=(/usr/games/gamemoderun "${wineserver_cmd[@]}")
-fi
-
-msgbox info "Launching wine server"
-if ! "${wineserver_cmd[@]}"; then
-    msgbox error "Failed to launch wine server!"
-    exit 1
-fi
-
-msgbox ok "Zwift closed, exiting"
+msgbox info "Zwift closed, exiting"

--- a/src/run_zwift.sh
+++ b/src/run_zwift.sh
@@ -51,16 +51,24 @@ msgbox() {
 }
 
 wine_task_info() {
-    local task="${1:?}"
-    wine tasklist /fo list /fi "IMAGENAME eq ${task}"
+    local task_name="${1:?}"
+    local filter="${2:-IMAGENAME}"
+    wine tasklist /fo list /fi "${filter} eq ${task_name}"
 }
 
 wine_task_pid() {
-    wine_task_info "${@}" | grep -m1 -Po '^PID:[\t ]*\K[0-9]+'
+    local task_name="${1:?}"
+    wine_task_info "${task_name}" | grep -m1 -Po '^PID:[\t ]*\K[0-9]+'
 }
 
 is_wine_task_running() {
-    [[ -n $(wine_task_info "${@}" || true) ]]
+    local task_name="${1:?}"
+    [[ -n $(wine_task_info "${task_name}" || true) ]]
+}
+
+is_wine_window_open() {
+    local window_title="${1:?}"
+    [[ -n $(wine_task_info "${window_title}" WINDOWTITLE || true) ]]
 }
 
 kill_wine_task() {

--- a/src/run_zwift.sh
+++ b/src/run_zwift.sh
@@ -167,20 +167,16 @@ if ! "${wine_cmd[@]}"; then
     exit 1
 fi
 
-# Important, without this sleep Zwift gets stuck in the launcher!
-for i in $(seq 3 -1 1); do
-    msgbox info "Waiting for Zwift to start... (${i})"
-    sleep 1
+# Wait for Zwift to start
+counter=1
+max_iterations=10
+while ! is_wine_window_open Zwift && [[ ${counter} -le ${max_iterations} ]]; do
+    msgbox info "Waiting for Zwift to start... (${counter}/${max_iterations})"
+    sleep 0.5
+    ((counter++))
 done
-
-if ! is_wine_task_running ZwiftApp.exe; then
+if ! is_wine_window_open Zwift; then
     msgbox error "Zwift has not started yet, giving up!"
-    exit 1
-fi
-
-# If launcher crashed, ZwiftApp.exe starts but does not do anything
-if ! is_wine_task_running ZwiftLauncher.exe; then
-    msgbox error "Zwift launcher exited unexpectedly. Did it crash?"
     exit 1
 fi
 

--- a/src/run_zwift.sh
+++ b/src/run_zwift.sh
@@ -72,6 +72,22 @@ kill_wine_tasks() {
     done
 }
 
+wait_until_running() {
+    local process_name="${1:?}"
+    local timeout="${2:-20}"
+    local counter=1
+
+    msgbox info "Waiting for ${process_name} to start..."
+
+    while ! pgrep -f "${process_name}" > /dev/null 2>&1 && [[ ${counter} -le ${timeout} ]]; do
+        msgbox debug "Waiting for ${process_name} to start... (${counter}/${timeout})"
+        sleep 0.1
+        ((counter++))
+    done
+
+    pgrep -f "${process_name}" > /dev/null 2>&1
+}
+
 ###########################
 ##### Configure Zwift #####
 
@@ -116,23 +132,19 @@ cleanup() {
 
 trap cleanup EXIT
 
-msgbox info "Launching wine server"
-
-declare -a wineserver_cmd
-wineserver_cmd=(wineserver)
-
 if [[ ${ZWIFT_NO_GAMEMODE} -eq 1 ]]; then
     msgbox warning "Not using gamemode"
 else
-    msgbox info "Using gamemode"
-    wineserver_cmd=(/usr/games/gamemoderun "${wineserver_cmd[@]}")
-fi
+    msgbox info "Starting wine server in gamemode"
 
-if "${wineserver_cmd[@]}"; then
-    msgbox ok "Launched wine server"
-else
-    msgbox error "Failed to launch wine server!"
-    exit 1
+    /usr/games/gamemoderun wineserver -w &
+
+    if wait_until_running wineserver; then
+        msgbox ok "Started wine server"
+    else
+        msgbox error "Failed to start wine server!"
+        exit 1
+    fi
 fi
 
 ##################################

--- a/src/run_zwift.sh
+++ b/src/run_zwift.sh
@@ -72,20 +72,31 @@ kill_wine_tasks() {
     done
 }
 
-wait_until_running() {
-    local process_name="${1:?}"
+wait_until() {
+    local condition="${1:?}"
     local timeout="${2:-20}"
+    local delay="${3:-0.1}"
     local counter=1
 
-    msgbox info "Waiting for ${process_name} to start..."
-
-    while ! pgrep -f "${process_name}" > /dev/null 2>&1 && [[ ${counter} -le ${timeout} ]]; do
-        msgbox debug "Waiting for ${process_name} to start... (${counter}/${timeout})"
-        sleep 0.1
+    while ! eval "${condition}" && [[ ${counter} -le ${timeout} ]]; do
+        msgbox debug "Waiting... (${counter}/${timeout})"
+        sleep "${delay}"
         ((counter++))
     done
 
-    pgrep -f "${process_name}" > /dev/null 2>&1
+    eval "${condition}"
+}
+
+wait_until_wine_task_started() {
+    local task_name="${1:?}"
+    msgbox info "Waiting for ${task_name} to start..."
+    wait_until "is_wine_task_running ${task_name}"
+}
+
+wait_until_process_started() {
+    local process_name="${1:?}"
+    msgbox info "Waiting for ${process_name} to start..."
+    wait_until "pgrep -f ${process_name} > /dev/null 2>&1"
 }
 
 ###########################
@@ -139,7 +150,7 @@ else
 
     /usr/games/gamemoderun wineserver -w &
 
-    if wait_until_running wineserver; then
+    if wait_until_process_started wineserver; then
         msgbox ok "Started wine server"
     else
         msgbox error "Failed to start wine server!"
@@ -165,7 +176,7 @@ fi
 
 msgbox info "Starting Zwift launcher using wine"
 
-if ! wine start ZwiftLauncher.exe SilentLaunch; then
+if ! wine start ZwiftLauncher.exe SilentLaunch || ! wait_until_wine_task_started ZwiftLauncher.exe; then
     msgbox error "Failed to start Zwift launcher using wine!"
     exit 1
 fi
@@ -181,7 +192,7 @@ msgbox info "Starting Zwift using wine"
 declare -a wine_cmd
 wine_cmd=(wine start /exec /bin/runfromprocess-rs.exe "${launcher_pid}" ZwiftApp.exe "${zwift_args[@]}")
 
-if ! "${wine_cmd[@]}"; then
+if ! "${wine_cmd[@]}" || ! wait_until_wine_task_started ZwiftApp.exe; then
     msgbox error "Failed to start Zwift using wine!"
     exit 1
 fi
@@ -194,8 +205,9 @@ msgbox ok "Zwift started using wine"
 ##################################
 ##### Wait for Zwift to exit #####
 
+counter=1
 while is_wine_task_running ZwiftApp.exe; do
-    msgbox debug "Waiting for Zwift to exit..."
+    msgbox debug "Waiting for Zwift to exit... ($((counter++)))"
     sleep 5
 done
 

--- a/src/run_zwift.sh
+++ b/src/run_zwift.sh
@@ -37,16 +37,8 @@ msgbox() {
     local type="${1:?}" # Type: info, ok, warning, error, debug
     local msg="${2:?}"  # Message: the message to display
 
-    make_timestamp() {
-        if [[ ${VERBOSITY} -ge 2 ]]; then
-            printf '%(%T)T|' -1
-        else
-            printf ''
-        fi
-    }
-
-    local timestamp
-    timestamp="$(make_timestamp)"
+    local timestamp=""
+    [[ ${VERBOSITY} -ge 2 ]] && printf -v timestamp '%(%T)T|' -1
 
     case ${type} in
         info) [[ ${VERBOSITY} -ge 1 ]] && echo -e "${COLOR_BLUE}[${CONTAINER_TOOL}|${timestamp}*] ${msg}${RESET_STYLE}" ;;

--- a/src/update-image.sh
+++ b/src/update-image.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+readonly DEBUG="${DEBUG:-0}"
+if [[ ${DEBUG} -eq 1 ]]; then set -x; fi
+
+if [[ -t 1 ]]; then
+    readonly COLOR_WHITE="\033[0;37m"
+    readonly COLOR_RED="\033[0;31m"
+    readonly COLOR_GREEN="\033[0;32m"
+    readonly COLOR_BLUE="\033[0;34m"
+    readonly COLOR_YELLOW="\033[0;33m"
+    readonly STYLE_BOLD="\033[1m"
+    readonly STYLE_UNDERLINE="\033[4m"
+    readonly RESET_STYLE="\033[0m"
+else
+    readonly COLOR_WHITE=""
+    readonly COLOR_RED=""
+    readonly COLOR_GREEN=""
+    readonly COLOR_BLUE=""
+    readonly COLOR_YELLOW=""
+    readonly STYLE_BOLD=""
+    readonly STYLE_UNDERLINE=""
+    readonly RESET_STYLE=""
+fi
+
+readonly VERBOSITY="${VERBOSITY:-1}"
+
+msgbox() {
+    local type="${1:?}" # Type: info, ok, warning, error, debug
+    local msg="${2:?}"  # Message: the message to display
+
+    local timestamp=""
+    [[ ${VERBOSITY} -ge 2 ]] && printf -v timestamp '%(%T)T|' -1
+
+    case ${type} in
+        info) [[ ${VERBOSITY} -ge 1 ]] && echo -e "${COLOR_BLUE}[${timestamp}*] ${msg}${RESET_STYLE}" ;;
+        ok) echo -e "${COLOR_GREEN}[${timestamp}✓] ${msg}${RESET_STYLE}" ;;
+        warning) echo -e "${COLOR_YELLOW}[${timestamp}!] ${msg}${RESET_STYLE}" ;;
+        error) echo -e "${COLOR_RED}[${timestamp}✗] ${msg}${RESET_STYLE}" >&2 ;;
+        debug) [[ ${VERBOSITY} -ge 3 ]] && echo -e "${COLOR_WHITE}[${timestamp}◉] ${msg}${RESET_STYLE}" ;;
+        *) echo "msgbox - unknown type ${type}" >&2 && exit 1 ;;
+    esac
+}
+
+command_exists() {
+    local cmd="${1:?}"
+    local cmd_path
+    cmd_path="$(command -v "${cmd}" 2> /dev/null)" && [[ -x ${cmd_path} ]]
+}
+
+echo -e "${COLOR_YELLOW}[!] ${STYLE_BOLD}Easily Zwift on linux!${RESET_STYLE}"
+echo -e "${COLOR_YELLOW}[!] ${STYLE_UNDERLINE}https://github.com/netbrain/zwift${RESET_STYLE}"
+
+msgbox info "Preparing to update scripts in Zwift image"
+
+################################
+##### Initialize variables #####
+
+# Initialize CONTAINER_TOOL: Use podman if available
+msgbox info "Looking for container tool"
+CONTAINER_TOOL="${CONTAINER_TOOL:-}"
+if [[ -z ${CONTAINER_TOOL} ]]; then
+    if command_exists podman; then
+        CONTAINER_TOOL="podman"
+    else
+        CONTAINER_TOOL="docker"
+    fi
+fi
+readonly CONTAINER_TOOL
+if command_exists "${CONTAINER_TOOL}"; then
+    msgbox ok "Found container tool: ${CONTAINER_TOOL}"
+else
+    msgbox error "Container tool ${CONTAINER_TOOL} not found"
+    msgbox error "  To install podman, see: https://podman.io/docs/installation"
+    msgbox error "  To install docker, see: https://docs.docker.com/get-started/get-docker/"
+    exit 1
+fi
+
+# Initialize IMAGE and VERSION based on container tool
+IMAGE="${IMAGE:-}"
+if [[ -z ${IMAGE} ]]; then
+    if [[ ${CONTAINER_TOOL} == "podman" ]]; then
+        IMAGE="localhost/zwift"
+    else
+        IMAGE="netbrain/zwift"
+    fi
+fi
+readonly IMAGE
+readonly VERSION="${VERSION:-latest}"
+msgbox info "Updating image ${IMAGE}:${VERSION}"
+
+# Initialize script constants
+readonly TEMP_CONTAINER_NAME="zwift-update-image"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+readonly SCRIPT_DIR
+declare -A SCRIPTS_MAP
+SCRIPTS_MAP["/bin/entrypoint"]="${SCRIPT_DIR}/entrypoint.sh"
+SCRIPTS_MAP["/bin/zwift-auth"]="${SCRIPT_DIR}/zwift-auth.sh"
+SCRIPTS_MAP["/bin/update_zwift.sh"]="${SCRIPT_DIR}/update_zwift.sh"
+SCRIPTS_MAP["/bin/run_zwift.sh"]="${SCRIPT_DIR}/run_zwift.sh"
+readonly SCRIPTS_MAP
+
+###################################
+##### Update scripts in image #####
+
+temp_dir=""
+cleanup_invoked=0
+any_script_updated=0
+
+cleanup() {
+    if [[ ${cleanup_invoked} -ne 1 ]]; then
+        msgbox info "Checking for temporary container"
+        if ${CONTAINER_TOOL} rm "${TEMP_CONTAINER_NAME}" > /dev/null 2>&1; then
+            msgbox ok "Removed temporary container"
+        else
+            msgbox info "No temporary container to remove"
+        fi
+
+        if [[ -n ${temp_dir} ]] && [[ -d ${temp_dir} ]]; then
+            msgbox info "Removing temporary directory"
+            rm -rf -- "${temp_dir}" || true
+        fi
+
+        cleanup_invoked=1
+    fi
+}
+
+trap cleanup EXIT
+
+msgbox info "Creating temporary directory"
+if temp_dir="$(mktemp -d "/tmp/${TEMP_CONTAINER_NAME}-XXXXXXXXXX")"; then
+    msgbox ok "Created temporary directory"
+    msgbox debug "Temporary directory: ${temp_dir}"
+else
+    msgbox error "Failed to create temporary directory"
+    exit 1
+fi
+
+msgbox info "Creating temporary container to update image scripts"
+if ${CONTAINER_TOOL} create --name "${TEMP_CONTAINER_NAME}" "${IMAGE}:${VERSION}"; then
+    msgbox ok "Created temporary container"
+    msgbox debug "Temporary container: ${TEMP_CONTAINER_NAME}"
+else
+    msgbox error "Failed to create temporary container"
+    exit 1
+fi
+
+for container_path in "${!SCRIPTS_MAP[@]}"; do
+    msgbox info "Checking if ${container_path} is up-to-date"
+    host_path="${SCRIPTS_MAP[${container_path}]}"
+    if ! ${CONTAINER_TOOL} cp "${TEMP_CONTAINER_NAME}:${container_path}" "${temp_dir}/container_script"; then
+        msgbox error "Failed to copy ${container_path} from container to host"
+        exit 1
+    fi
+    container_sum="$(sha256sum "${temp_dir}/container_script" | awk '{print $1}')"
+    host_sum="$(sha256sum "${host_path}" | awk '{print $1}')"
+    msgbox debug "Checksum: ${container_sum} (${TEMP_CONTAINER_NAME}:${container_path})"
+    msgbox debug "Checksum: ${host_sum} (${host_path})"
+    if [[ ${container_sum} == "${host_sum}" ]]; then
+        msgbox ok "${container_path} in container is up-to-date"
+        continue
+    fi
+    msgbox info "${container_path} is not up-to-date, updating script in container"
+    if ${CONTAINER_TOOL} cp "${host_path}" "${TEMP_CONTAINER_NAME}:${container_path}"; then
+        msgbox ok "Copied ${host_path} to ${container_path} in temporary container"
+    else
+        msgbox info "Failed to copy ${host_path} to ${container_path} in temporary container"
+        exit 1
+    fi
+    any_script_updated=1
+done
+
+if [[ ${any_script_updated} -eq 1 ]]; then
+    msgbox info "Some scripts were updated"
+    msgbox info "Updating image with changes from temporary container"
+    if ${CONTAINER_TOOL} commit "${TEMP_CONTAINER_NAME}" "${IMAGE}:${VERSION}"; then
+        msgbox ok "Tagged Zwift container as ${IMAGE}:${VERSION}"
+    else
+        msgbox error "Failed to commit container changes to image"
+        exit 1
+    fi
+else
+    msgbox ok "Scripts in ${IMAGE}:${VERSION} are already up-to-date"
+fi
+
+cleanup
+
+########################
+##### Launch Zwift #####
+
+export IMAGE
+export VERSION
+export DONT_CHECK=1
+export DONT_PULL=1
+export ZWIFT_FG=1
+
+"${SCRIPT_DIR}/zwift.sh"

--- a/src/update_zwift.sh
+++ b/src/update_zwift.sh
@@ -130,23 +130,16 @@ install_zwift() {
     msgbox info "Starting wine with custom mono version"
     WINEDLLOVERRIDES="mscoree,mshtml=" wineboot -u || return 1
 
-    # install prerequisites using winetricks
-    # dotnet20: to prevent error dialog with CloseLauncher.exe
-    # dotnet48: required by Zwift
-    # d3dcompiler_47: required for Vulkan shaders
     msgbox info "Installing prerequisites using winetricks"
     winetricks -q dotnet20 dotnet48 d3dcompiler_47 || return 1
 
-    # download and install webview 2
     msgbox info "Downloading and installing webview2"
     wget -O webview2-setup.exe https://go.microsoft.com/fwlink/p/?LinkId=2124703 || return 1
     wine webview2-setup.exe /silent /install || return 1
 
-    # enable Wayland support, requires DISPLAY to be blank to use Wayland
     msgbox info "Enabling Wayland support"
     wine reg.exe add HKCU\\Software\\Wine\\Drivers /v Graphics /d x11,wayland || return 1
 
-    # download and install zwift
     msgbox info "Downloading and installing Zwift"
     wget https://cdn.zwift.com/app/ZwiftSetup.exe || return 1
     wine ZwiftSetup.exe /SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /NOCANCEL || return 1

--- a/src/update_zwift.sh
+++ b/src/update_zwift.sh
@@ -32,16 +32,8 @@ msgbox() {
     local type="${1:?}" # Type: info, ok, warning, error, debug
     local msg="${2:?}"  # Message: the message to display
 
-    make_timestamp() {
-        if [[ ${VERBOSITY} -ge 2 ]]; then
-            printf '%(%T)T|' -1
-        else
-            printf ''
-        fi
-    }
-
-    local timestamp
-    timestamp="$(make_timestamp)"
+    local timestamp=""
+    [[ ${VERBOSITY} -ge 2 ]] && printf -v timestamp '%(%T)T|' -1
 
     case ${type} in
         info) [[ ${VERBOSITY} -ge 1 ]] && echo -e "${COLOR_BLUE}[${CONTAINER_TOOL}|${timestamp}*] ${msg}${RESET_STYLE}" ;;

--- a/src/update_zwift.sh
+++ b/src/update_zwift.sh
@@ -98,12 +98,9 @@ update_zwift_using_launcher() {
 
     local counter=1
     local max_iterations=60 # 60 * 5s = 5 minutes max
+
     # also stop if launcher exits before update finishes, so we don't hang forever
-    while [[ ${zwift_current_version} != "${zwift_latest_version}" ]] && is_wine_task_running ZwiftLauncher.exe; do
-        if [[ ${counter} -gt ${max_iterations} ]]; then
-            msgbox error "Update timed out after $((max_iterations * 5)) seconds"
-            return 1
-        fi
+    while [[ ${zwift_current_version} != "${zwift_latest_version}" ]] && [[ ${counter} -le ${max_iterations} ]] && is_wine_task_running ZwiftLauncher.exe; do
         msgbox info "Updating Zwift... (${counter}/${max_iterations})"
         msgbox debug "Current version: ${zwift_current_version}; Latest version: ${zwift_latest_version}"
         sleep 5
@@ -111,9 +108,13 @@ update_zwift_using_launcher() {
         ((counter++))
     done
 
-    # if launcher exited unexpectedly, Zwift is still at the old version
+    # if launcher exited unexpectedly or update timeout, Zwift is still at the old version
     if [[ ${zwift_current_version} != "${zwift_latest_version}" ]]; then
-        msgbox error "Launcher exited unexpectedly, update did not complete"
+        if [[ ${counter} -gt ${max_iterations} ]]; then
+            msgbox error "Update timed out after $((counter * 5)) seconds"
+        else
+            msgbox error "Launcher exited unexpectedly, update did not complete"
+        fi
         return 1
     fi
 

--- a/src/update_zwift.sh
+++ b/src/update_zwift.sh
@@ -46,12 +46,13 @@ msgbox() {
 }
 
 wine_task_info() {
-    local task="${1:?}"
-    wine tasklist /fo list /fi "IMAGENAME eq ${task}"
+    local task_name="${1:?}"
+    wine tasklist /fo list /fi "IMAGENAME eq ${task_name}"
 }
 
 is_wine_task_running() {
-    [[ -n $(wine_task_info "${@}" || true) ]]
+    local task_name="${1:?}"
+    [[ -n $(wine_task_info "${task_name}" || true) ]]
 }
 
 get_current_version() {

--- a/src/update_zwift.sh
+++ b/src/update_zwift.sh
@@ -119,12 +119,6 @@ update_zwift_using_launcher() {
         return 1
     fi
 
-    local i
-    for i in $(seq 5 -1 1); do
-        msgbox info "Waiting for update to finish... (${i})"
-        sleep 1
-    done
-
     msgbox ok "Zwift updated to version ${zwift_latest_version}"
 }
 

--- a/src/update_zwift.sh
+++ b/src/update_zwift.sh
@@ -69,7 +69,7 @@ get_current_version() {
 }
 
 get_latest_version() {
-    wget --no-cache --quiet -O - http://cdn.zwift.com/gameassets/Zwift_Updates_Root/Zwift_ver_cur.xml \
+    wget --no-cache --quiet -O - https://cdn.zwift.com/gameassets/Zwift_Updates_Root/Zwift_ver_cur.xml \
         | grep -oP 'sversion="\K.*?(?=")' | cut -f 1 -d ' ' \
         || return 1
 }

--- a/src/update_zwift.sh
+++ b/src/update_zwift.sh
@@ -45,6 +45,15 @@ msgbox() {
     esac
 }
 
+wine_task_info() {
+    local task="${1:?}"
+    wine tasklist /fo list /fi "IMAGENAME eq ${task}"
+}
+
+is_wine_task_running() {
+    [[ -n $(wine_task_info "${@}" || true) ]]
+}
+
 get_current_version() {
     # if Zwift_ver_cur_filename.txt exists, it holds the true current version filename
     # if it does not exist, use Zwift_ver_cur.xml as fallback
@@ -90,7 +99,7 @@ update_zwift_using_launcher() {
     local counter=1
     local max_iterations=60 # 60 * 5s = 5 minutes max
     # also stop if launcher exits before update finishes, so we don't hang forever
-    while [[ ${zwift_current_version} != "${zwift_latest_version}" ]] && pgrep -f ZwiftLauncher.exe > /dev/null 2>&1; do
+    while [[ ${zwift_current_version} != "${zwift_latest_version}" ]] && is_wine_task_running ZwiftLauncher.exe; do
         if [[ ${counter} -gt ${max_iterations} ]]; then
             msgbox error "Update timed out after $((max_iterations * 5)) seconds"
             return 1

--- a/src/update_zwift.sh
+++ b/src/update_zwift.sh
@@ -126,10 +126,6 @@ update_zwift_using_launcher() {
 }
 
 install_zwift() {
-    # prevent wine from trying to install a different mono version
-    msgbox info "Starting wine with custom mono version"
-    WINEDLLOVERRIDES="mscoree,mshtml=" wineboot -u || return 1
-
     msgbox info "Installing prerequisites using winetricks"
     winetricks -q corefonts dotnet48 d3dcompiler_47 || return 1
 

--- a/src/update_zwift.sh
+++ b/src/update_zwift.sh
@@ -131,7 +131,7 @@ install_zwift() {
     WINEDLLOVERRIDES="mscoree,mshtml=" wineboot -u || return 1
 
     msgbox info "Installing prerequisites using winetricks"
-    winetricks -q dotnet20 dotnet48 d3dcompiler_47 || return 1
+    winetricks -q dotnet48 d3dcompiler_47 || return 1
 
     msgbox info "Downloading and installing webview2"
     wget -O webview2-setup.exe https://go.microsoft.com/fwlink/p/?LinkId=2124703 || return 1

--- a/src/update_zwift.sh
+++ b/src/update_zwift.sh
@@ -131,7 +131,7 @@ install_zwift() {
     WINEDLLOVERRIDES="mscoree,mshtml=" wineboot -u || return 1
 
     msgbox info "Installing prerequisites using winetricks"
-    winetricks -q dotnet48 d3dcompiler_47 || return 1
+    winetricks -q corefonts dotnet48 d3dcompiler_47 || return 1
 
     msgbox info "Downloading and installing webview2"
     wget -O webview2-setup.exe https://go.microsoft.com/fwlink/p/?LinkId=2124703 || return 1

--- a/src/update_zwift.sh
+++ b/src/update_zwift.sh
@@ -123,6 +123,10 @@ update_zwift_using_launcher() {
 }
 
 install_zwift() {
+    # prevent wine from installing mono and gecko
+    msgbox info "Initializing wine"
+    WINEDLLOVERRIDES="mscoree,mshtml=" wineboot -u || return 1
+
     msgbox info "Installing prerequisites using winetricks"
     winetricks -q corefonts dotnet48 d3dcompiler_47 || return 1
 

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -47,16 +47,9 @@ msgbox() {
     local msg="${2:?}"     # Message: the message to display
     local timeout="${3:-}" # Optional timeout: if explicitly set to 0, wait for user input to continue
 
-    make_timestamp() {
-        if [[ ${VERBOSITY} -ge 2 ]]; then
-            printf '%(%T)T|' -1
-        else
-            printf ''
-        fi
-    }
-
-    local timestamp
-    timestamp="$(make_timestamp)"
+    local timestamp=""
+    update_timestamp() { [[ ${VERBOSITY} -ge 2 ]] && printf -v timestamp '%(%T)T|' -1; }
+    update_timestamp
 
     case ${type} in
         info) [[ ${VERBOSITY} -ge 1 ]] && echo -e "${COLOR_BLUE}[${timestamp}*] ${msg}${RESET_STYLE}" ;;
@@ -67,7 +60,7 @@ msgbox() {
             local ans=""
             if [[ -n ${timeout} ]] && [[ ${timeout} -gt 0 ]]; then
                 while [[ ${timeout} -gt 0 ]]; do
-                    timestamp="$(make_timestamp)"
+                    update_timestamp
                     echo -ne "${COLOR_YELLOW}[${timestamp}?] ${STYLE_BOLD}${STYLE_UNDERLINE}${msg} (Default no in ${timeout} seconds.) [y/N]:${RESET_STYLE} "
                     read -rt 1 -n 1 ans
                     if [[ -n ${ans} ]]; then
@@ -93,7 +86,7 @@ msgbox() {
     if [[ -n ${timeout} ]]; then
         if [[ ${timeout} -gt 0 ]]; then
             while [[ ${timeout} -gt 0 ]]; do
-                timestamp="$(make_timestamp)"
+                update_timestamp
                 echo -e "${COLOR_BLUE}[${timestamp}*] Continuing in ${timeout} seconds...${RESET_STYLE}"
                 sleep 1
                 ((timeout--))


### PR DESCRIPTION
## Summary

Make some changes with the goal of improving stability.

- Update winetricks and dependencies installed with winetricks
  - Winetricks 20260125, webview2 in the zwift launcher works!
  - Remove dotnot20, not needed anymore
  - Add corefonts, fixes wine warnings about missing fonts
- Wine
  - ~Install wine mono and gecko (instead of launching wine with `WINEDLLOVERRIDES="mscoree,mshtml="`)~
  - ~This fixes .net framework compilation errors~
- Dockerfile
  - Update rust base image
  - [Use ADD instruction instead of RUN wget](https://docs.docker.com/build/building/best-practices/#add-or-copy)
  - Use checksums for downloads (this has come up a few times, but it's actually easy with ADD, so no real reason anymore to avoid doing this)
  - Use ADD to clone the runfromprocess git repo at the desired commit
  - Add `DEBIAN_FRONTEND="noninteractive"` to apt-get commands to prevent dialog creation errors
- Refactor run_zwift.sh
  - Launch wineserver first, so it doesn't automatically start first and then gets killed and relaunched with gamemode
  - Use the windows task manager with wine to manage wine processes, keeping windows stuff in windows
  - Wait for wine processes where possible
  - Kill the zwift launcher as soon as possible, this essentially kills the launcher immediately, so it won't have the time to start update processes etc, effectively bypassing it entirely
- Add update-image.sh script
  - Similar to the workflow, it assumes the image exists and updates the scripts in it
  - Makes it quicker to work on the container scripts. Only run build-image.sh once (slow), then use update-image.sh when making additional changes to the scripts (quick).
- Minor changes
  - Optimize the msgbox function, reducing the number of lines of code
  - Fix the zwift version file url (use https instead of http)
  - Don't add the container user to the sudo group. It doesn't work with podman anyway because we use `--userns=keep`. Easy to get root access with `$CONTAINER_TOOL exec -it -u root zwift-$USER bash`.

@philipbalinov this includes some of the stuff you proposed.

## Discussion

I've been experimenting with gamemode to see what it is actually doing and how well it is working. As it stands now, the wineserver is started in gamemode. And gamemode is indeed active as long as the wineserver is running. This will prevent sleep, screensaver, ..., but it won't do anything to optimize performance.

If we want to use gamemode to optimize performance, we have to launch zwift itself with gamemode. I've added the missing 32-bit gamemode libraries that appear to be required to do so. But it's currently not possible because zwift is started with runfromprocess. If we start runfromprocess in gamemode, gamemode will activate, optimize runfromprocess, optimize zwift, and then when runfromprocess stops (zwift has launched) immediately remove the optimizations and turn off again.