### PR TITLE
Launch zwift using gamemode

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -30,7 +30,8 @@ foo@bar:~$ WINE_EXPERIMENTAL_WAYLAND="1" zwift # start zwift using Wayland inste
 
 ### Configuration file
 
-The zwift script automatically loads environment variables from the following configuration files:
+You can persist configuration options by creating a file. The zwift script will automatically load environment variables from
+these files, if present:
 
 - `$HOME/.config/zwift/config`
 - `$HOME/.config/zwift/$USER-config`

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -19,7 +19,6 @@ sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/netbrain/zwift/mast
 This script will:
 
 - Download the Zwift container image
-- Create necessary configuration files
 - Add zwift command to your system path
 - Create desktop shortcut
 

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -18,32 +18,32 @@ nav_order: 1
 
 ## Required Software
 
-### Container Runtimes
+### Supported Container Runtimes
 
-- **Docker**
-  - Install from [Docker documentation](https://docs.docker.com/get-docker/)
-- **Podman** (Alternative)
-  - Version 4.3+ recommended
-  - Install from [Podman installation guide](https://podman.io/getting-started/installation)
+#### Podman (Recommended)
 
-{: .warning }
-**Podman 4.3 and earlier**: Does not support `--userns=keep-id:uid=xxx,gid=xxx` and will not start correctly, this impacts
-Ubuntu 22.04 and related builds such as PopOS! 22.04.
+- Install by following the [Podman install guide](https://podman.io/docs/installation#installing-on-linux)
+- Podman 4.3 and earlier do not support `--userns=keep-id` and will not start correctly. This impacts Ubuntu 22.04 and related
+  builds such as PopOS! 22.04.
+
+#### Docker
+
+- Rootless docker is not supported!
+- Install by following the [Docker CE install guide](https://docs.docker.com/engine/install/)
+- Add your user account to the docker group to be able to use docker without requiring sudo `sudo usermod -aG docker $USER`.
 
 ### Additional Dependencies for NVIDIA graphics cards
 
-- **NVIDIA Container Toolkit**
-  - Install from [NVIDIA Container Toolkit installation guide](
-    https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
-  - Podman: Also follow the [Container Device Interface guide](
-    https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/cdi-support.html)
+#### NVIDIA Container Toolkit
 
-{: .note }
-**Podman and NVIDIA Container Toolkit before v1.18.0**: The cdi specification file needs to be generated manually each time the
-NVIDIA driver is updated using the following command: `sudo nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.yaml`
+- Install by following the [NVIDIA Container Toolkit installation guide][install-nvctk]
+- Podman
+  - Also follow the [Container Device Interface guide][install-nvcdi]
+  - Container Toolkit version v1.17.9 and earlier do not automatically update the cdi specification file. Regenerate it manually
+    after NVIDIA driver updates by running the command: `sudo nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.yaml`.
+- Docker
+  - If Zwift fails to launch, try setting `VGA_DEVICE_FLAG=(--device="nvidia.com/gpu=all")`. See
+    [this issue](https://github.com/netbrain/zwift/issues/208) for context.
 
-{: .note }
-> If you're running Docker with cdi and Zwift fails to launch, try the long form
-> `VGA_DEVICE_FLAG=(--device="nvidia.com/gpu=all")` (instead of `--gpus=all`).
->
-> See <https://github.com/netbrain/zwift/issues/208> for context.
+[install-nvctk]: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
+[install-nvcdi]: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/cdi-support.html

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -6,11 +6,22 @@ nav_order: 3
 
 # How do I connect my trainer, heart rate monitor, etc?
 
-You can [use your phone as a bridge](https://support.zwift.com/using-the-zwift-companion-app-Hybn8qzPr).
+## ANT+
 
-For example, your Wahoo Kickr and Apple Watch connect to the Zwift Companion app on your iPhone; then the Companion app connects
+ANT+ devices are not supported.
+
+## Bluetooth
+
+Wine does not fully support bluetooth yet. Instead, you can [use your phone as a bridge][companion-app-bridge] to connect your
+bluetooth devices to Zwift.
+
+For example, your Wahoo Kickr and Apple Watch connect to the Zwift Companion app on your iPhone, then the Companion app connects
 over wifi to your PC running Zwift.
 
-{: .note }
-If you are using a direct connect (wifi or ethernet) enabled trainer, you may need to set `NETWORKING="host"` for Zwift to be
-able to communicate to the device.
+[companion-app-bridge]: https://support.zwift.com/en_us/using-the-zwift-companion-app-as-a-bridge-ByAnUzlLj
+
+## Direct Connect
+
+If you are using a direct connect (wifi or ethernet) enabled trainer, you do not need the Companion app. Setting the
+[NETWORKING](../../configuration/options/#networking) configuration option to `NETWORKING="host"` will allow Zwift to discover
+your device and connect to it directly.

--- a/src/run_zwift.sh
+++ b/src/run_zwift.sh
@@ -133,8 +133,8 @@ if [[ -n ${ZWIFT_USERNAME} ]] && [[ -n ${ZWIFT_PASSWORD} ]]; then
     fi
 fi
 
-######################################################
-##### Start (and automatically stop) wine server #####
+##########################################
+##### Automatically stop wine server #####
 
 cleanup() {
     msgbox info "Stopping wine server"
@@ -142,21 +142,6 @@ cleanup() {
 }
 
 trap cleanup EXIT
-
-if [[ ${ZWIFT_NO_GAMEMODE} -eq 1 ]]; then
-    msgbox warning "Not using gamemode"
-else
-    msgbox info "Starting wine server in gamemode"
-
-    /usr/games/gamemoderun wineserver -w &
-
-    if wait_until_process_started wineserver; then
-        msgbox ok "Started wine server"
-    else
-        msgbox error "Failed to start wine server!"
-        exit 1
-    fi
-fi
 
 ##################################
 ##### Start Zwift using wine #####
@@ -189,10 +174,17 @@ fi
 msgbox ok "Zwift launcher started using wine"
 msgbox info "Starting Zwift using wine"
 
-declare -a wine_cmd
-wine_cmd=(wine start /exec /bin/runfromprocess-rs.exe "${launcher_pid}" ZwiftApp.exe "${zwift_args[@]}")
+declare -a zwift_cmd
 
-if ! "${wine_cmd[@]}" || ! wait_until_wine_task_started ZwiftApp.exe; then
+if [[ ${ZWIFT_NO_GAMEMODE} -eq 1 ]]; then
+    msgbox info "Not using gamemode"
+    zwift_cmd=(wine start /exec /bin/runfromprocess-rs.exe "${launcher_pid}" ZwiftApp.exe "${zwift_args[@]}")
+else
+    msgbox info "Using gamemode"
+    zwift_cmd=(/usr/games/gamemoderun wine /bin/runfromprocess-rs.exe "${launcher_pid}" ZwiftApp.exe "${zwift_args[@]}")
+fi
+
+if ! "${zwift_cmd[@]}" || ! wait_until_wine_task_started ZwiftApp.exe; then
     msgbox error "Failed to start Zwift using wine!"
     exit 1
 fi

--- a/src/run_zwift.sh
+++ b/src/run_zwift.sh
@@ -93,12 +93,6 @@ wait_until_wine_task_started() {
     wait_until "is_wine_task_running ${task_name}"
 }
 
-wait_until_process_started() {
-    local process_name="${1:?}"
-    msgbox info "Waiting for ${process_name} to start..."
-    wait_until "pgrep -f ${process_name} > /dev/null 2>&1"
-}
-
 ###########################
 ##### Configure Zwift #####
 

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -448,8 +448,13 @@ if [[ -n ${ZWIFT_OVERRIDE_RESOLUTION} ]]; then
     container_env_vars+=(ZWIFT_OVERRIDE_RESOLUTION="${ZWIFT_OVERRIDE_RESOLUTION}")
 fi
 
-# Pass environment variable to container if gamemode should be disabled
+# Check if gamemode should be enabled
 if [[ ${ZWIFT_NO_GAMEMODE} -eq 1 ]]; then
+    container_env_vars+=(ZWIFT_NO_GAMEMODE="1")
+elif command_exists gamemoded; then
+    msgbox ok "Gamemode is installed, enabling gamemode for Zwift"
+else
+    msgbox info "Gamemode is not installed, disabling gamemode for Zwift"
     container_env_vars+=(ZWIFT_NO_GAMEMODE="1")
 fi
 


### PR DESCRIPTION
## Summary

Launch Zwift itself using gamemode instead of the wine server.

- Detect if gamemode is installed on the host, if not, don't attempt use it to launch zwift (prevent #351)
- Launch Zwift using gamemode instead of wineserver (discussion in #347)
- Fix confusing documentation about configuration files (confusion in #349)

## Implementation

Don't manually start wineserver in gamemode. Instead let it start automatically and launch zwift itself using gamemode.

```bash
if [[ ${ZWIFT_NO_GAMEMODE} -eq 1 ]]; then
    msgbox info "Not using gamemode"
    zwift_cmd=(wine start /exec /bin/runfromprocess-rs.exe "${launcher_pid}" ZwiftApp.exe "${zwift_args[@]}")
else
    msgbox info "Using gamemode"
    zwift_cmd=(/usr/games/gamemoderun wine /bin/runfromprocess-rs.exe "${launcher_pid}" ZwiftApp.exe "${zwift_args[@]}")
fi
```

```text
[podman|20:20:36|*] Starting Zwift using wine
[podman|20:20:36|*] Using gamemode
gamemodeauto: 
[podman|20:20:36|*] Waiting for ZwiftApp.exe to start...
[podman|20:20:36|*] Killing Zwift launcher and background tasks
[podman|20:20:36|◉] Killing wine task 'ZwiftLauncher.exe'
[podman|20:20:36|◉] Killing wine task 'ZwiftWindowsCrashHandler.exe'
[podman|20:20:36|◉] Killing wine task 'MicrosoftEdgeUpdate.exe'
[podman|20:20:36|✓] Zwift started using wine
[podman|20:20:36|◉] Waiting for Zwift to exit... (1)
[podman|20:20:41|◉] Waiting for Zwift to exit... (2)
[podman|20:20:46|◉] Waiting for Zwift to exit... (3)
```

### Proof that it is working

Checking that gamemode is indeed active on the host system while Zwift is running.

1. Check using the gamemode daemon on the host system

   ```console
   glenn@glenn-main-pc:~/Documents/Projects/zwift-linux(fix/detect-gamemode)$ gamemoded -s
   gamemode is active
   ```

   Returns active as long as Zwift is running. Inactive before. And inactive again after Zwift stopped.

2. Check using journalctl

   ```console
   glenn@glenn-main-pc:~/Documents/Projects/zwift-linux(fix/detect-gamemode)$ ps afux | grep ZwiftApp.exe
   glenn     200765 86.1  2.0 4614792 2026724 pts/0 Rl+  22:16   1:39  |           \_ ZwiftApp.exe --token={...}
   ```

   ```console
   glenn@glenn-main-pc:~/Documents/Projects/zwift-linux(fix/detect-gamemode)$ journalctl --user --unit=gamemoded --follow
   mei 06 22:16:59 glenn-main-pc gamemoded[47479]: Detected wine for client 200765 [/opt/wine-devel/bin/wine64-preloader].
   mei 06 22:16:59 glenn-main-pc gamemoded[47479]: Adding game: 200765 [/opt/wine-devel/bin/wine64-preloader]
   mei 06 22:16:59 glenn-main-pc gamemoded[47479]: Setting ioprio value...
   mei 06 22:16:59 glenn-main-pc gamemoded[47479]: Pinning process...
   ```