### PR TITLE
Fix updating when installed as user

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ foo@bar:~$ ffmpeg -i example.mp4 -i palette.png -filter_complex \
 ### Install
 
 ```console
-sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/netbrain/zwift/master/bin/install.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/netbrain/zwift/master/bin/install.sh)"
 ```
 
-This will put the `zwift.sh` script on your `$PATH` and add a desktop icon to `/usr/local/share/applications`.
+This will put the `zwift.sh` script on your `$PATH` and add a desktop icon to `$HOME/.local/share/applications`.
 
 **NOTE**: Icon may not show until logging off and back in.
 

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -69,6 +69,7 @@ readonly ZWIFT_LOGO="https://raw.githubusercontent.com/netbrain/zwift/master/bin
 readonly ZWIFT_DESKTOP_ENTRY="https://raw.githubusercontent.com/netbrain/zwift/master/bin/Zwift.desktop"
 
 if [[ -t 1 ]]; then
+    readonly INTERACTIVE_TERMINAL=1
     readonly COLOR_WHITE="\033[0;37m"
     readonly COLOR_RED="\033[0;31m"
     readonly COLOR_GREEN="\033[0;32m"
@@ -78,6 +79,7 @@ if [[ -t 1 ]]; then
     readonly STYLE_UNDERLINE="\033[4m"
     readonly RESET_STYLE="\033[0m"
 else
+    readonly INTERACTIVE_TERMINAL=0
     readonly COLOR_WHITE=""
     readonly COLOR_RED=""
     readonly COLOR_GREEN=""
@@ -274,6 +276,11 @@ install_netbrain_zwift() {
 
 echo -e "${COLOR_YELLOW}[!] ${STYLE_BOLD}Easily Zwift on linux!${RESET_STYLE}"
 echo -e "${COLOR_YELLOW}[!] ${STYLE_UNDERLINE}https://github.com/netbrain/zwift${RESET_STYLE}"
+
+if [[ ${INTERACTIVE_TERMINAL} -eq 0 ]] && [[ ${auto_confirm} -eq 0 ]]; then
+    msgbox warning "Detected non-interactive environment, enabling auto-confirm"
+    auto_confirm=1
+fi
 
 if [[ ${uninstall} -eq 1 ]]; then
     uninstall_netbrain_zwift

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -5,15 +5,29 @@ readonly DEBUG="${DEBUG:-0}"
 if [[ ${DEBUG} -eq 1 ]]; then set -x; fi
 
 print_usage() {
-    echo "Usage: install [ -v | --script-version COMMIT_HASH ]"
-    echo "               [ -y | --auto-confirm ]"
-    echo "               [ -h | --help ]"
+    echo "Install or uninstall netbrain/zwift"
+    echo "Invoking this script with sudo will perform a system wide install"
+    echo "Invoking this script without sudo will perform a user local install"
+    echo ""
+    echo "Usage:"
+    echo "    ${0} [ -v | --script-version COMMIT_HASH ]"
+    echo "    ${0//?/ } [ -y | --auto-confirm ]"
+    echo "    ${0//?/ } [ -u | --uninstall ] "
+    echo "    ${0//?/ } [ -h | --help ]"
+    echo ""
+    echo "Options:"
+    echo "    --script-version COMMIT_HASH    Install a specific netbrain/zwift version instead of master"
+    echo "    --auto-confirm                  Automatically confirm installation"
+    echo "    --uninstall                     Uninstall netbrain/zwift"
+    echo "    --help                          Print usage"
     exit 2
 }
 
+script_args=("${@}")
 script_version="master"
 auto_confirm=0
-if ! options="$(getopt -n install -o "v:yh" -l "script-version:,auto-confirm,help" -- "${@}")"; then
+uninstall=0
+if ! options="$(getopt -n install -o "v:yuh" -l "script-version:,auto-confirm,uninstall,help" -- "${@}")"; then
     print_usage
 fi
 eval set -- "${options}"
@@ -25,6 +39,10 @@ while :; do
             ;;
         -y | --auto-confirm)
             auto_confirm=1
+            shift
+            ;;
+        -u | --uninstall)
+            uninstall=1
             shift
             ;;
         -h | --help)
@@ -42,6 +60,10 @@ while :; do
 done
 
 readonly VERBOSITY="${VERBOSITY:-1}"
+readonly SYSTEM_BIN_DIR="/usr/local/bin"
+readonly SYSTEM_SHARE_DIR="/usr/local/share"
+readonly USER_BIN_DIR="${XDG_BIN_HOME:-${HOME}/.local/bin}"
+readonly USER_SHARE_DIR="${XDG_DATA_HOME:-${HOME}/.local/share}"
 readonly ZWIFT_SCRIPT="https://raw.githubusercontent.com/netbrain/zwift/${script_version}/src/zwift.sh"
 readonly ZWIFT_LOGO="https://raw.githubusercontent.com/netbrain/zwift/master/bin/Zwift.svg"
 readonly ZWIFT_DESKTOP_ENTRY="https://raw.githubusercontent.com/netbrain/zwift/master/bin/Zwift.desktop"
@@ -94,105 +116,167 @@ msgbox() {
     esac
 }
 
-exit_failure() {
-    msgbox error "Zwift install failed! 😭"
-    exit 1
+invoked_as_root() {
+    [[ ${EUID} -eq 0 ]]
 }
 
-determine_install_location() {
-    if [[ ${EUID} -eq 0 ]]; then
-        root_bin="/usr/local/bin"
-        root_share="/usr/local/share"
-    else
-        # user install
-        root_bin="${XDG_BIN_HOME:-${HOME}/.local/bin}"
-        root_share="${XDG_DATA_HOME:-${HOME}/.local/share}"
-    fi
+uninstall_netbrain_zwift() {
+    remove_file() {
+        local file="${1:?}"
 
-    msgbox info "Installing Zwift to:"
-    msgbox info "  binaries → ${root_bin}"
-    msgbox info "  data     → ${root_share}"
-}
+        msgbox info "  Removing ${file}"
 
-ask_user_confirmation() {
-    if msgbox question "Are you sure you want to install Zwift?"; then
-        msgbox ok "Proceeding with Zwift installation"
-    else
-        msgbox info "Aborted Zwift installation"
-        msgbox warning "Zwift not installed! 😥"
-        exit 2
-    fi
-}
-
-create_directories() {
-    create_directory() {
-        local directory="${1:?}"
-
-        msgbox info "  Creating directory ${directory}"
-
-        if ! mkdir -p "${directory}"; then
-            msgbox error "Could not create ${directory}, aborting"
-            exit_failure
+        if ! rm -f -- "${file}"; then
+            msgbox warning "  Failed to remove ${file}"
         fi
     }
 
-    msgbox info "Creating directories"
-
-    create_directory "${root_bin}"
-    create_directory "${root_share}/icons/hicolor/scalable/apps"
-    create_directory "${root_share}/applications"
-
-    msgbox ok "Directories created"
-}
-
-download_zwift() {
-    download_asset() {
-        local destination="${1:?}"
-        local url="${2:?}"
-
-        msgbox info "  Downloading ${url}"
-
-        if ! curl -fsSLo "${destination}" "${url}"; then
-            msgbox error "Downloading ${url} failed, aborting"
-            exit_failure
+    remove_user_install() {
+        if [[ -f "${USER_BIN_DIR}/zwift" ]]; then
+            if msgbox question "Found user install of netbrain/zwift, remove it?"; then
+                msgbox ok "Removing user install"
+                remove_file "${USER_BIN_DIR}/zwift"
+                remove_file "${USER_SHARE_DIR}/icons/hicolor/scalable/apps/zwift.svg"
+                remove_file "${USER_SHARE_DIR}/applications/Zwift.desktop}"
+            else
+                msgbox ok "Keeping netbrain/zwift user install 👌"
+            fi
+        else
+            msgbox info "No user install of netbrain/zwift found"
         fi
     }
 
-    msgbox info "Downloading Zwift"
+    remove_system_install() {
+        if [[ -f "${SYSTEM_BIN_DIR}/zwift" ]]; then
+            if invoked_as_root; then
+                if msgbox question "Found system install of netbrain/zwift, remove it?"; then
+                    msgbox ok "Removing system install"
+                    remove_file "${SYSTEM_BIN_DIR}/zwift"
+                    remove_file "${SYSTEM_SHARE_DIR}/icons/hicolor/scalable/apps/zwift.svg"
+                    remove_file "${SYSTEM_SHARE_DIR}/applications/Zwift.desktop}"
+                else
+                    msgbox ok "Keeping netbrain/zwift system install 👌"
+                fi
+            else
+                msgbox warning "Found system install of netbrain/zwift, but removing it requires root"
+                msgbox warning "  To uninstall run 'sudo ${0} ${script_args[*]}'"
+            fi
+        else
+            msgbox info "No system install of netbrain/zwift found"
+        fi
+    }
 
-    download_asset "${root_bin}/zwift" "${ZWIFT_SCRIPT}"
-    download_asset "${root_share}/icons/hicolor/scalable/apps/zwift.svg" "${ZWIFT_LOGO}"
-    download_asset "${root_share}/applications/Zwift.desktop" "${ZWIFT_DESKTOP_ENTRY}"
-
-    if ! chmod 755 "${root_bin}/zwift"; then
-        msgbox error "Failed to set permissions for ${root_bin}/zwift, aborting"
-        exit_failure
-    fi
-
-    msgbox ok "Zwift download complete"
+    msgbox info "Preparing to uninstall netbrain/zwift"
+    msgbox info "The zwift container image, volume, and configuration will not be removed"
+    remove_user_install
+    remove_system_install
+    msgbox ok "Uninstall complete!"
 }
 
-check_in_path() {
-    msgbox info "Checking if 'zwift' is in PATH"
+install_netbrain_zwift() {
+    exit_failure() {
+        msgbox error "Zwift install failed! 😭"
+        exit 1
+    }
 
-    if case ":${PATH}:" in *":${root_bin}:"*) true ;; *) false ;; esac then
-        msgbox info "  ${root_bin} is in your PATH"
-        msgbox ok "Zwift can be launched using the 'zwift' command"
-    else
-        msgbox warning "${root_bin} is not in your PATH"
-        msgbox warning "You may need to add it to your PATH for the 'zwift' command to work"
-    fi
+    determine_install_location() {
+        if invoked_as_root; then
+            root_bin="${SYSTEM_BIN_DIR}"
+            root_share="${SYSTEM_SHARE_DIR}"
+        else
+            root_bin="${USER_BIN_DIR}"
+            root_share="${USER_SHARE_DIR}"
+        fi
+
+        msgbox info "Installing Zwift to:"
+        msgbox info "  binaries → ${root_bin}"
+        msgbox info "  data     → ${root_share}"
+    }
+
+    ask_user_confirmation() {
+        if msgbox question "Are you sure you want to install Zwift?"; then
+            msgbox ok "Proceeding with netbrain/zwift installation"
+        else
+            msgbox info "Aborted netbrain/zwift installation"
+            msgbox warning "Zwift not installed! 😥"
+            exit 2
+        fi
+    }
+
+    create_directories() {
+        create_directory() {
+            local directory="${1:?}"
+
+            msgbox info "  Creating directory ${directory}"
+
+            if ! mkdir -p "${directory}"; then
+                msgbox error "Could not create ${directory}, aborting"
+                exit_failure
+            fi
+        }
+
+        msgbox info "Creating directories"
+
+        create_directory "${root_bin}"
+        create_directory "${root_share}/icons/hicolor/scalable/apps"
+        create_directory "${root_share}/applications"
+
+        msgbox ok "Directories created"
+    }
+
+    download_zwift() {
+        download_asset() {
+            local destination="${1:?}"
+            local url="${2:?}"
+
+            msgbox info "  Downloading ${url}"
+
+            if ! curl -fsSLo "${destination}" "${url}"; then
+                msgbox error "Downloading ${url} failed, aborting"
+                exit_failure
+            fi
+        }
+
+        msgbox info "Downloading netbrain/zwift"
+
+        download_asset "${root_bin}/zwift" "${ZWIFT_SCRIPT}"
+        download_asset "${root_share}/icons/hicolor/scalable/apps/zwift.svg" "${ZWIFT_LOGO}"
+        download_asset "${root_share}/applications/Zwift.desktop" "${ZWIFT_DESKTOP_ENTRY}"
+
+        if ! chmod 755 "${root_bin}/zwift"; then
+            msgbox error "Failed to set permissions for ${root_bin}/zwift, aborting"
+            exit_failure
+        fi
+
+        msgbox ok "Download complete"
+    }
+
+    check_in_path() {
+        msgbox info "Checking if 'zwift' is in PATH"
+
+        if case ":${PATH}:" in *":${root_bin}:"*) true ;; *) false ;; esac then
+            msgbox info "  ${root_bin} is in your PATH"
+            msgbox ok "Zwift can be launched using the 'zwift' command"
+        else
+            msgbox warning "${root_bin} is not in your PATH"
+            msgbox warning "You may need to add it to your PATH for the 'zwift' command to work"
+        fi
+    }
+
+    msgbox info "Preparing to install netbrain/zwift"
+    determine_install_location
+    ask_user_confirmation
+    create_directories
+    download_zwift
+    check_in_path
+    msgbox ok "Install complete! 🥳"
 }
 
 echo -e "${COLOR_YELLOW}[!] ${STYLE_BOLD}Easily Zwift on linux!${RESET_STYLE}"
 echo -e "${COLOR_YELLOW}[!] ${STYLE_UNDERLINE}https://github.com/netbrain/zwift${RESET_STYLE}"
 
-msgbox info "Preparing to install Zwift"
-
-determine_install_location
-ask_user_confirmation
-create_directories
-download_zwift
-check_in_path
-
-msgbox ok "Zwift install complete! 🥳"
+if [[ ${uninstall} -eq 1 ]]; then
+    uninstall_netbrain_zwift
+else
+    install_netbrain_zwift
+fi

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -128,7 +128,7 @@ uninstall_netbrain_zwift() {
 
         msgbox info "  Removing ${file}"
 
-        if ! rm -f -- "${file}"; then
+        if ! rm -- "${file}" > /dev/null 2>&1; then
             msgbox warning "  Failed to remove ${file}"
         fi
     }

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -139,7 +139,7 @@ uninstall_netbrain_zwift() {
                 msgbox ok "Removing user install"
                 remove_file "${USER_BIN_DIR}/zwift"
                 remove_file "${USER_SHARE_DIR}/icons/hicolor/scalable/apps/zwift.svg"
-                remove_file "${USER_SHARE_DIR}/applications/Zwift.desktop}"
+                remove_file "${USER_SHARE_DIR}/applications/Zwift.desktop"
             else
                 msgbox ok "Keeping netbrain/zwift user install 👌"
             fi
@@ -155,7 +155,7 @@ uninstall_netbrain_zwift() {
                     msgbox ok "Removing system install"
                     remove_file "${SYSTEM_BIN_DIR}/zwift"
                     remove_file "${SYSTEM_SHARE_DIR}/icons/hicolor/scalable/apps/zwift.svg"
-                    remove_file "${SYSTEM_SHARE_DIR}/applications/Zwift.desktop}"
+                    remove_file "${SYSTEM_SHARE_DIR}/applications/Zwift.desktop"
                 else
                     msgbox ok "Keeping netbrain/zwift system install 👌"
                 fi

--- a/docs/advanced/switch-to-user-install.md
+++ b/docs/advanced/switch-to-user-install.md
@@ -1,0 +1,35 @@
+---
+title: Switch to user install
+nav_order: 6
+parent: Advanced
+---
+
+# How do I switch from a system wide install to a user local install?
+
+If you have installed netbrain/zwift system wide and want to switch to a user local install instead so you don't need to enter
+your root password when there is an update available, follow the steps below:
+
+1. Download the install script and make it executable
+
+   ```console
+   foo@bar:~$ wget https://raw.githubusercontent.com/netbrain/zwift/master/bin/install.sh
+   foo@bar:~$ chmod u+x install.sh
+   ```
+
+2. Uninstall netbrain/zwift (but keep your settings)
+
+   ```console
+   foo@bar:~$ sudo ./install.sh --uninstall --auto-confirm
+   ```
+
+3. Install netbrain/zwift for the current user
+
+   ```console
+   foo@bar:~$ ./install.sh --auto-confirm
+   ```
+
+4. Remove the install script since it is no longer needed
+
+   ```console
+   foo@bar:~$ rm install.sh
+   ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,11 +4,17 @@ parent: Getting Started
 nav_order: 2
 ---
 
-# Installation Methods
+# Installing, Updating and Uninstalling
 
 ## Automatic Installation
 
-![example.gif](/assets/images/example.gif)
+### User local Installation (Recommended)
+
+To install netbrain/zwift only for the current user, run:
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/netbrain/zwift/master/bin/install.sh)"
+```
 
 ### System wide Installation
 
@@ -16,14 +22,6 @@ To install netbrain/zwift for all users on your system, run:
 
 ```bash
 sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/netbrain/zwift/master/bin/install.sh)"
-```
-
-### User local Installation
-
-To install netbrain/zwift only for the current user, run:
-
-```bash
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/netbrain/zwift/master/bin/install.sh)"
 ```
 
 This script will:
@@ -34,17 +32,17 @@ This script will:
 
 ## How can I update Zwift?
 
-The `zwift.sh` script will update Zwift by checking for new image versions on every launch, however if you are not using this
-then you will have to pull `netbrain/zwift:latest` from time to time in order to be on the latest version.
-
 There is a github action in place that will update Zwift on a scheduled basis and publish new versions to docker hub.
+
+The `zwift.sh` script will update Zwift by checking for new image and script versions on every launch, however if you are not
+using this then you will have to pull `netbrain/zwift:latest` from time to time in order to be on the latest version.
 
 ## How can I uninstall netbrain/zwift?
 
 Download the `install.sh` script and invoke it with the `--uninstall` argument.
 
-- If invoked with sudo, both the user local and system wide installation will be removed.
-- If invoked without sudo, only the user local installation will be removed.
+- If invoked with sudo, both the user local and system wide installation can be removed.
+- If invoked without sudo, only the user local installation can be removed.
 
 ```console
 foo@bar:~$ wget https://raw.githubusercontent.com/netbrain/zwift/master/bin/install.sh

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -18,18 +18,14 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/netbrain/zwift/master/bi
 
 ### System wide Installation
 
-To install netbrain/zwift for all users on your system, run:
+To install netbrain/zwift for all users on your system, run the `install.sh` script as root with sudo.
 
-```bash
-sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/netbrain/zwift/master/bin/install.sh)"
-```
-
-This script will:
+### The install script will
 
 - Add the zwift command to your system path
-- Create a desktop shortcut
+- Create a desktop shortcut (you may need to log off and on again for the icon to show up)
 
-## First Launch
+### First Launch
 
 The first time zwift is started, it will download the netbrain/zwift container image. This image is approximately 5.5 GiB in
 size, so it will take some time to download. After the container image is downloaded, the Zwift game will be launched.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -60,3 +60,16 @@ Uninstalling netbrain/zwift will:
 - Remove the scripts and desktop shortcut
 - Keep the Zwift container image
 - Keep your Zwift settings (volume and configuration files)
+
+To remove the netbrain/zwift container image, run:
+
+```console
+foo@bar:~$ podman rmi docker.io/netbrain/zwift    # or docker rmi docker.io/netbrain/zwift
+```
+
+To remove your Zwift settings, run:
+
+```console
+foo@bar:~$ podman volume rm zwift-$USER           # or docker volume rm zwift-$USER
+foo@bar:~$ rm -rf ~/.config/zwift
+```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -26,9 +26,13 @@ sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/netbrain/zwift/mast
 
 This script will:
 
-- Download the Zwift container image
 - Add the zwift command to your system path
 - Create a desktop shortcut
+
+## First Launch
+
+The first time zwift is started, it will download the netbrain/zwift container image. This image is approximately 5.5 GiB in
+size, so it will take some time to download. After the container image is downloaded, the Zwift game will be launched.
 
 ## How can I update Zwift?
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -8,23 +8,33 @@ nav_order: 2
 
 ## Automatic Installation
 
-### One-Line Installation
-
 ![example.gif](/assets/images/example.gif)
+
+### System wide Installation
+
+To install netbrain/zwift for all users on your system, run:
 
 ```bash
 sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/netbrain/zwift/master/bin/install.sh)"
 ```
 
+### User local Installation
+
+To install netbrain/zwift only for the current user, run:
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/netbrain/zwift/master/bin/install.sh)"
+```
+
 This script will:
 
 - Download the Zwift container image
-- Add zwift command to your system path
-- Create desktop shortcut
+- Add the zwift command to your system path
+- Create a desktop shortcut
 
 ## How can I update Zwift?
 
-The `zwift.sh` script will update zwift by checking for new image versions on every launch, however if you are not using this
+The `zwift.sh` script will update Zwift by checking for new image versions on every launch, however if you are not using this
 then you will have to pull `netbrain/zwift:latest` from time to time in order to be on the latest version.
 
-There is a github action in place that will update zwift on a scheduled basis and publish new versions to docker hub.
+There is a github action in place that will update Zwift on a scheduled basis and publish new versions to docker hub.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -38,3 +38,23 @@ The `zwift.sh` script will update Zwift by checking for new image versions on ev
 then you will have to pull `netbrain/zwift:latest` from time to time in order to be on the latest version.
 
 There is a github action in place that will update Zwift on a scheduled basis and publish new versions to docker hub.
+
+## How can I uninstall netbrain/zwift?
+
+Download the `install.sh` script and invoke it with the `--uninstall` argument.
+
+- If invoked with sudo, both the user local and system wide installation will be removed.
+- If invoked without sudo, only the user local installation will be removed.
+
+```console
+foo@bar:~$ wget https://raw.githubusercontent.com/netbrain/zwift/master/bin/install.sh
+foo@bar:~$ chmod u+x install.sh
+foo@bar:~$ ./install.sh --uninstall
+foo@bar:~$ rm install.sh
+```
+
+Uninstalling netbrain/zwift will:
+
+- Remove the scripts and desktop shortcut
+- Keep the Zwift container image
+- Keep your Zwift settings (volume and configuration files)

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,8 +11,10 @@ Easily Zwift on Linux! :100:
 
 ## Quick Start
 
+Just one line to get Zwift up and running!
+
 ```bash
-sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/netbrain/zwift/master/bin/install.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/netbrain/zwift/master/bin/install.sh)"
 ```
 
 ![example.gif](/assets/images/example.gif)

--- a/src/build-image.sh
+++ b/src/build-image.sh
@@ -81,7 +81,7 @@ if [[ -z ${CONTAINER_TOOL} ]]; then
 fi
 readonly CONTAINER_TOOL
 if command_exists "${CONTAINER_TOOL}"; then
-    msgbox ok "Found container tool: ${CONTAINER_TOOL}"
+    msgbox ok "Found container tool: ${CONTAINER_TOOL} ($(${CONTAINER_TOOL} --version || true))"
 else
     msgbox error "Container tool ${CONTAINER_TOOL} not found"
     msgbox error "  To install podman, see: https://podman.io/docs/installation"

--- a/src/update-image.sh
+++ b/src/update-image.sh
@@ -69,7 +69,7 @@ if [[ -z ${CONTAINER_TOOL} ]]; then
 fi
 readonly CONTAINER_TOOL
 if command_exists "${CONTAINER_TOOL}"; then
-    msgbox ok "Found container tool: ${CONTAINER_TOOL}"
+    msgbox ok "Found container tool: ${CONTAINER_TOOL} ($(${CONTAINER_TOOL} --version || true))"
 else
     msgbox error "Container tool ${CONTAINER_TOOL} not found"
     msgbox error "  To install podman, see: https://podman.io/docs/installation"

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -250,7 +250,7 @@ upgrade_script() {
 
     msgbox info "Running install script"
 
-    install_cmd=(bash -c "${install_script}" -- --script-version="${SCRIPT_VERSION}")
+    install_cmd=(bash -c "${install_script}" -- --script-version="${SCRIPT_VERSION}" --auto-confirm)
     if installed_as_root; then
         install_cmd=(pkexec env PATH="${PATH}" "${install_cmd[@]}")
     fi

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -11,6 +11,9 @@ if [[ ${DEBUG} -eq 1 ]]; then set -x; fi
 # - VERBOSITY=3 (also debug messages)
 VERBOSITY="${VERBOSITY:-1}" # updated after loading user config files
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+readonly SCRIPT_DIR
+
 readonly USER_CONFIG_DIR="${HOME}/.config/zwift"
 readonly WINE_USER_HOME="/home/user/.wine/drive_c/users/user"
 readonly ZWIFT_HOME="/home/user/.wine/drive_c/Program Files (x86)/Zwift"
@@ -232,7 +235,12 @@ check_script_up_to_date() {
 }
 
 upgrade_script() {
+    installed_as_root() {
+        [[ ${SCRIPT_DIR} == "/usr/local/bin" ]]
+    }
+
     local install_script
+    local install_cmd
 
     msgbox info "Downloading latest install script"
     if ! install_script="$(curl -fsSL https://raw.githubusercontent.com/netbrain/zwift/master/bin/install.sh)"; then
@@ -241,7 +249,13 @@ upgrade_script() {
     fi
 
     msgbox info "Running install script"
-    if ! pkexec env PATH="${PATH}" bash -c "${install_script}" -- --script-version="${SCRIPT_VERSION}"; then
+
+    install_cmd=(bash -c "${install_script}" -- --script-version="${SCRIPT_VERSION}")
+    if installed_as_root; then
+        install_cmd=(pkexec env PATH="${PATH}" "${install_cmd[@]}")
+    fi
+
+    if ! "${install_cmd[@]}"; then
         msgbox error "Install script failed"
         return 1
     fi

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -11,9 +11,6 @@ if [[ ${DEBUG} -eq 1 ]]; then set -x; fi
 # - VERBOSITY=3 (also debug messages)
 VERBOSITY="${VERBOSITY:-1}" # updated after loading user config files
 
-SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
-readonly SCRIPT_DIR
-
 readonly USER_CONFIG_DIR="${HOME}/.config/zwift"
 readonly WINE_USER_HOME="/home/user/.wine/drive_c/users/user"
 readonly ZWIFT_HOME="/home/user/.wine/drive_c/Program Files (x86)/Zwift"
@@ -116,8 +113,17 @@ command_exists() {
     cmd_path="$(command -v "${cmd}" 2> /dev/null)" && [[ -x ${cmd_path} ]]
 }
 
+invoked_as_root() {
+    [[ ${EUID} -eq 0 ]]
+}
+
 echo -e "${COLOR_YELLOW}[!] ${STYLE_BOLD}Easily Zwift on linux!${RESET_STYLE}"
 echo -e "${COLOR_YELLOW}[!] ${STYLE_UNDERLINE}https://github.com/netbrain/zwift${RESET_STYLE}"
+
+if invoked_as_root; then
+    msgbox error "It is not supported to run the zwift script as root."
+    exit 1
+fi
 
 msgbox info "Preparing to launch Zwift"
 
@@ -236,8 +242,8 @@ check_script_up_to_date() {
 }
 
 upgrade_script() {
-    installed_as_root() {
-        [[ ${SCRIPT_DIR} == "/usr/local/bin" ]]
+    installed_as_user() {
+        [[ -O ${0} ]]
     }
 
     local install_script
@@ -252,7 +258,7 @@ upgrade_script() {
     msgbox info "Running install script"
 
     install_cmd=(bash -c "${install_script}" -- --script-version="${SCRIPT_VERSION}" --auto-confirm)
-    if installed_as_root; then
+    if ! installed_as_user; then
         install_cmd=(pkexec env PATH="${PATH}" "${install_cmd[@]}")
     fi
 

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -60,6 +60,7 @@ msgbox() {
         warning) echo -e "${COLOR_YELLOW}[${timestamp}!] ${msg}${RESET_STYLE}" ;;
         error) echo -e "${COLOR_RED}[${timestamp}✗] ${msg}${RESET_STYLE}" >&2 ;;
         question)
+            [[ ${INTERACTIVE_TERMINAL} -eq 0 ]] && return 0
             local ans=""
             if [[ -n ${timeout} ]] && [[ ${timeout} -gt 0 ]]; then
                 while [[ ${timeout} -gt 0 ]]; do
@@ -86,7 +87,7 @@ msgbox() {
         *) echo "msgbox - unknown type ${type}" >&2 && exit 1 ;;
     esac
 
-    if [[ -n ${timeout} ]]; then
+    if [[ -n ${timeout} ]] && [[ ${INTERACTIVE_TERMINAL} -eq 1 ]]; then
         if [[ ${timeout} -gt 0 ]]; then
             while [[ ${timeout} -gt 0 ]]; do
                 update_timestamp

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -195,7 +195,7 @@ if [[ -z ${CONTAINER_TOOL} ]]; then
 fi
 readonly CONTAINER_TOOL
 if command_exists "${CONTAINER_TOOL}"; then
-    msgbox ok "Found container tool: ${CONTAINER_TOOL}"
+    msgbox ok "Found container tool: ${CONTAINER_TOOL} ($(${CONTAINER_TOOL} --version || true))"
 else
     msgbox error "Container tool ${CONTAINER_TOOL} not found"
     msgbox error "  To install podman, see: https://podman.io/docs/installation"


### PR DESCRIPTION
## Summary

Related to #356.

Fix automatic zwift script update forcing system wide install

- If netbrain/zwift is installed for the local user, don't use pkexec when invoking the install script in the update procedure.
- Add an uninstall option to the install script. This makes it easier for users to switch from a system wide install to a user local install if they want to.
- Recommend a user local installation instead of a system wide installation in the documentation.

Fix unable to update zwift script in non-interactive environment

- In a non-interactive environment, the question to confirm the zwift script update will timeout and default to false. The zwift script will therefore never be updated, while the container image will.
- Instead, assume yes in a non-interactive environment. The user can set DONT_CHECK/DONT_PULL to disable updates.

## Details

Uninstalling netbrain/zwift will:

- Remove the scripts and desktop entry
- Keep the Zwift container image
- Keep all configuration (volume and config files)