### PR TITLE
Strip screen number from DISPLAY when locating X11 socket

### DIFF
--- a/src/build-image.sh
+++ b/src/build-image.sh
@@ -127,7 +127,11 @@ fi
 
 # Configure window manager
 msgbox info "Using X11 window manager"
-if [[ -z ${DISPLAY} ]] || [[ ! -S /tmp/.X11-unix/X${DISPLAY#*:} ]]; then
+# DISPLAY is [host]:displaynumber[.screennumber] but the X11 socket is named
+# by the display number alone, so strip the host prefix and screen suffix.
+x11_display="${DISPLAY#*:}"
+x11_display="${x11_display%.*}"
+if [[ -z ${DISPLAY} ]] || [[ ! -S /tmp/.X11-unix/X${x11_display} ]]; then
     msgbox error "X11 is not running!"
     exit 1
 fi

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -591,9 +591,13 @@ if [[ ${WINE_EXPERIMENTAL_WAYLAND} -eq 1 ]]; then
     fi
 fi
 if [[ -z ${window_manager} ]]; then
+    # DISPLAY is [host]:displaynumber[.screennumber] but the X11 socket is named
+    # by the display number alone, so strip the host prefix and screen suffix.
+    x11_display="${DISPLAY#*:}"
+    x11_display="${x11_display%.*}"
     if [[ -n ${WAYLAND_DISPLAY} ]]; then
         window_manager="XWayland"
-    elif [[ -n ${DISPLAY} ]] && [[ -S /tmp/.X11-unix/X${DISPLAY#*:} ]]; then
+    elif [[ -n ${DISPLAY} ]] && [[ -S /tmp/.X11-unix/X${x11_display} ]]; then
         window_manager="XOrg"
     else # no window manager, tty?
         msgbox error "Can't run Zwift without window manager"


### PR DESCRIPTION
## Problem

Window manager detection fails with `Can't run Zwift without window manager` when `$DISPLAY` includes a screen number, e.g. `:0.0`.

The check builds the socket path from `${DISPLAY#*:}`, which strips the host prefix but keeps the screen number:

- `DISPLAY=:0.0` produces `/tmp/.X11-unix/X0.0`
- The actual socket is `/tmp/.X11-unix/X0`

The path doesn't exist, so detection falls through to the error and exits.

## Fix

The X11 socket is named by the display number alone. Strip the screen-number suffix before building the path:

```sh
x11_display="${DISPLAY#*:}"   # 0.0  or  0
x11_display="${x11_display%.*}"  # 0
```

Verified across formats: `:0.0` -> `X0`, `:0` -> `X0`, `:1` -> `X1`, `localhost:10.0` -> `X10`, `:1.0` -> `X1`.

## Risk / scope

One-line behavioural change in window manager detection. No effect on `DISPLAY` values without a screen number (the `%.*` strip is a no-op when there's no dot).

## Tested

- `shellcheck src/zwift.sh` passes (`enable=all`).
- Parameter-expansion logic verified against the DISPLAY formats above.

Fixes #363