### PR TITLE
Fix star history chart with sealed_token embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,15 @@ and tricks :smiley:
 
 ## ⭐ Star History (for fun and giggles)
 
-[![Star History Chart](https://api.star-history.com/svg?repos=netbrain/zwift&type=Date)](https://star-history.com/#netbrain/zwift&Date)
+<!-- markdownlint-disable line-length -->
+<a href="https://www.star-history.com/?repos=netbrain%2Fzwift&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=netbrain/zwift&type=date&theme=dark&legend=top-left&sealed_token=P-GZDYcjNPXSdBBWv6fYd1q9l2QYn8RwOAazVYzhNjLm13SxhxXvWH23XUounM3eZAJJBr5inEk9A_US1aG03d8WpTJXkWZMl4s2nD8aVFNAqxc9p1YG9phmq_aCPO5FmQt7BOSE_8SvTJe7rKLd-9uaVV2NATlbf0_I9s5jVTorIS9JBoDqfSw99rm3" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=netbrain/zwift&type=date&legend=top-left&sealed_token=P-GZDYcjNPXSdBBWv6fYd1q9l2QYn8RwOAazVYzhNjLm13SxhxXvWH23XUounM3eZAJJBr5inEk9A_US1aG03d8WpTJXkWZMl4s2nD8aVFNAqxc9p1YG9phmq_aCPO5FmQt7BOSE_8SvTJe7rKLd-9uaVV2NATlbf0_I9s5jVTorIS9JBoDqfSw99rm3" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=netbrain/zwift&type=date&legend=top-left&sealed_token=P-GZDYcjNPXSdBBWv6fYd1q9l2QYn8RwOAazVYzhNjLm13SxhxXvWH23XUounM3eZAJJBr5inEk9A_US1aG03d8WpTJXkWZMl4s2nD8aVFNAqxc9p1YG9phmq_aCPO5FmQt7BOSE_8SvTJe7rKLd-9uaVV2NATlbf0_I9s5jVTorIS9JBoDqfSw99rm3" />
+ </picture>
+</a>
+<!-- markdownlint-enable line-length -->
 
 [lint-everything-src]: https://github.com/netbrain/zwift/actions/workflows/lint_everything.yaml/badge.svg
 [lint-everything-href]: https://github.com/netbrain/zwift/actions/workflows/lint_everything.yaml

--- a/README.md
+++ b/README.md
@@ -116,15 +116,8 @@ and tricks :smiley:
 
 ## ⭐ Star History (for fun and giggles)
 
-<!-- markdownlint-disable line-length -->
-<a href="https://www.star-history.com/?repos=netbrain%2Fzwift&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=netbrain/zwift&type=date&theme=dark&legend=top-left&sealed_token=P-GZDYcjNPXSdBBWv6fYd1q9l2QYn8RwOAazVYzhNjLm13SxhxXvWH23XUounM3eZAJJBr5inEk9A_US1aG03d8WpTJXkWZMl4s2nD8aVFNAqxc9p1YG9phmq_aCPO5FmQt7BOSE_8SvTJe7rKLd-9uaVV2NATlbf0_I9s5jVTorIS9JBoDqfSw99rm3" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=netbrain/zwift&type=date&legend=top-left&sealed_token=P-GZDYcjNPXSdBBWv6fYd1q9l2QYn8RwOAazVYzhNjLm13SxhxXvWH23XUounM3eZAJJBr5inEk9A_US1aG03d8WpTJXkWZMl4s2nD8aVFNAqxc9p1YG9phmq_aCPO5FmQt7BOSE_8SvTJe7rKLd-9uaVV2NATlbf0_I9s5jVTorIS9JBoDqfSw99rm3" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=netbrain/zwift&type=date&legend=top-left&sealed_token=P-GZDYcjNPXSdBBWv6fYd1q9l2QYn8RwOAazVYzhNjLm13SxhxXvWH23XUounM3eZAJJBr5inEk9A_US1aG03d8WpTJXkWZMl4s2nD8aVFNAqxc9p1YG9phmq_aCPO5FmQt7BOSE_8SvTJe7rKLd-9uaVV2NATlbf0_I9s5jVTorIS9JBoDqfSw99rm3" />
- </picture>
-</a>
-<!-- markdownlint-enable line-length -->
+[![Star History Chart](https://api.star-history.com/chart?repos=netbrain/zwift&type=date&legend=top-left&sealed_token=P-GZDYcjNPXSdBBWv6fYd1q9l2QYn8RwOAazVYzhNjLm13SxhxXvWH23XUounM3eZAJJBr5inEk9A_US1aG03d8WpTJXkWZMl4s2nD8aVFNAqxc9p1YG9phmq_aCPO5FmQt7BOSE_8SvTJe7rKLd-9uaVV2NATlbf0_I9s5jVTorIS9JBoDqfSw99rm3)](https://www.star-history.com/?repos=netbrain%2Fzwift&type=date&legend=top-left)
+
 
 [lint-everything-src]: https://github.com/netbrain/zwift/actions/workflows/lint_everything.yaml/badge.svg
 [lint-everything-href]: https://github.com/netbrain/zwift/actions/workflows/lint_everything.yaml

--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ and tricks :smiley:
 [![Star History Chart](https://api.star-history.com/chart?repos=netbrain/zwift&type=date&legend=top-left&sealed_token=P-GZDYcjNPXSdBBWv6fYd1q9l2QYn8RwOAazVYzhNjLm13SxhxXvWH23XUounM3eZAJJBr5inEk9A_US1aG03d8WpTJXkWZMl4s2nD8aVFNAqxc9p1YG9phmq_aCPO5FmQt7BOSE_8SvTJe7rKLd-9uaVV2NATlbf0_I9s5jVTorIS9JBoDqfSw99rm3)](https://www.star-history.com/?repos=netbrain%2Fzwift&type=date&legend=top-left)
 <!-- markdownlint-enable line-length -->
 
-
 [lint-everything-src]: https://github.com/netbrain/zwift/actions/workflows/lint_everything.yaml/badge.svg
 [lint-everything-href]: https://github.com/netbrain/zwift/actions/workflows/lint_everything.yaml
 [zwift-updater-src]: https://github.com/netbrain/zwift/actions/workflows/zwift_updater.yaml/badge.svg

--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ and tricks :smiley:
 
 ## ⭐ Star History (for fun and giggles)
 
+<!-- markdownlint-disable line-length -->
 [![Star History Chart](https://api.star-history.com/chart?repos=netbrain/zwift&type=date&legend=top-left&sealed_token=P-GZDYcjNPXSdBBWv6fYd1q9l2QYn8RwOAazVYzhNjLm13SxhxXvWH23XUounM3eZAJJBr5inEk9A_US1aG03d8WpTJXkWZMl4s2nD8aVFNAqxc9p1YG9phmq_aCPO5FmQt7BOSE_8SvTJe7rKLd-9uaVV2NATlbf0_I9s5jVTorIS9JBoDqfSw99rm3)](https://www.star-history.com/?repos=netbrain%2Fzwift&type=date&legend=top-left)
+<!-- markdownlint-enable line-length -->
 
 
 [lint-everything-src]: https://github.com/netbrain/zwift/actions/workflows/lint_everything.yaml/badge.svg


### PR DESCRIPTION
## Background
GitHub now requires authentication on the stargazers endpoint. Anonymous `GET /repos/netbrain/zwift/stargazers` returns HTTP 401, so the old anonymous star-history embed returns HTTP 500 and no longer renders in the README.

## Change
Switch the star history section to star-history's `sealed_token` embed. The sealed token is an encrypted wrapper around a metadata-read-only token; the raw PAT is not exposed and GitHub secret scanning does not match it, so it is safe to commit in a public README.

## Note
Rendering depends on star-history's service. During testing it intermittently returned `timeout of 10000ms exceeded` (server-side, not a token error). Confirm the chart renders before relying on the merge.

Closes #367