### PR TITLE
Remove broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,6 @@ and tricks :smiley:
     cake, and have it too by creating `vgpus` for vms that leverage the host
     gpu, no dedicated gpu required
 
-## ⭐ Star History (for fun and giggles)
-
-<!-- markdownlint-disable line-length -->
-[![Star History Chart](https://api.star-history.com/chart?repos=netbrain/zwift&type=date&legend=top-left&sealed_token=P-GZDYcjNPXSdBBWv6fYd1q9l2QYn8RwOAazVYzhNjLm13SxhxXvWH23XUounM3eZAJJBr5inEk9A_US1aG03d8WpTJXkWZMl4s2nD8aVFNAqxc9p1YG9phmq_aCPO5FmQt7BOSE_8SvTJe7rKLd-9uaVV2NATlbf0_I9s5jVTorIS9JBoDqfSw99rm3)](https://www.star-history.com/?repos=netbrain%2Fzwift&type=date&legend=top-left)
-<!-- markdownlint-enable line-length -->
-
 [lint-everything-src]: https://github.com/netbrain/zwift/actions/workflows/lint_everything.yaml/badge.svg
 [lint-everything-href]: https://github.com/netbrain/zwift/actions/workflows/lint_everything.yaml
 [zwift-updater-src]: https://github.com/netbrain/zwift/actions/workflows/zwift_updater.yaml/badge.svg


### PR DESCRIPTION
## Background
The star history chart depends on the GitHub stargazers endpoint, which now requires authentication (anonymous returns HTTP 401). PR #368 switched the embed to a star-history `sealed_token`, but it still returns HTTP 500 from star-history's backend, so the chart does not render.

## Change
Remove the Star History section from the README. A reliably rendering chart would need a CI-generated static image, which is not worth it for a for-fun section.

Closes #367