### PR TITLE
Workaround for Zwift issue with AppData/Local/Zwift being a volume

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -42,6 +42,7 @@ ARG WINETRICKS_CHECKSUM=431f82fc74000e6c864409f1d8fb495d696c03928808e3e8acffc451
 # - libegl1 and libgl1 for GL library
 # - libvulkan1 for vulkan loader library
 # - procps for pgrep
+# - rsync to synchronize zwift volume with zwift appdata (WORKAROUND issue 366)
 # - wget for downloading winehq key
 # - winbind for ntml_auth required by zwift/wine
 # - xdg-utils seems to be a dependency of wayland
@@ -59,6 +60,7 @@ RUN dpkg --add-architecture i386 \
         libgamemodeauto0.i386 \
         libvulkan1 \
         procps \
+        rsync \
         wget \
         winbind \
         xdg-utils \

--- a/src/run_zwift.sh
+++ b/src/run_zwift.sh
@@ -30,6 +30,7 @@ readonly ZWIFT_NO_GAMEMODE="${ZWIFT_NO_GAMEMODE:-0}"
 
 readonly WINE_USER_HOME="/home/user/.wine/drive_c/users/user"
 readonly ZWIFT_HOME="/home/user/.wine/drive_c/Program Files (x86)/Zwift"
+readonly ZWIFT_VOLUME="${WINE_USER_HOME}/AppData/Local/ZwiftVolume" # WORKAROUND issue 366 (remove when fixed)
 readonly ZWIFT_DOCS="${WINE_USER_HOME}/AppData/Local/Zwift"
 readonly ZWIFT_PREFS="${ZWIFT_DOCS}/prefs.xml"
 
@@ -92,6 +93,16 @@ wait_until_wine_task_started() {
     msgbox info "Waiting for ${task_name} to start..."
     wait_until "is_wine_task_running ${task_name}"
 }
+
+#########################################################################################
+##### Sync Zwift volume to Zwift AppData - WORKAROUND issue 366 (remove when fixed) #####
+
+msgbox info "Synchronizing Zwift settings"
+if rsync -au "${ZWIFT_VOLUME}/" "${ZWIFT_DOCS}/"; then
+    msgbox ok "Synchronized Zwift settings"
+else
+    msgbox warning "Failed to synchronize Zwift settings"
+fi
 
 ###########################
 ##### Configure Zwift #####
@@ -196,5 +207,13 @@ while is_wine_task_running ZwiftApp.exe; do
     msgbox debug "Waiting for Zwift to exit... ($((counter++)))"
     sleep 5
 done
+
+# WORKAROUND issue 366 (remove when fixed)
+msgbox info "Synchronizing Zwift settings"
+if rsync -au "${ZWIFT_DOCS}/" "${ZWIFT_VOLUME}/"; then
+    msgbox ok "Synchronized Zwift settings"
+else
+    msgbox warning "Failed to synchronize Zwift settings"
+fi
 
 msgbox info "Zwift closed, exiting"

--- a/src/zwift.sh
+++ b/src/zwift.sh
@@ -14,7 +14,7 @@ VERBOSITY="${VERBOSITY:-1}" # updated after loading user config files
 readonly USER_CONFIG_DIR="${HOME}/.config/zwift"
 readonly WINE_USER_HOME="/home/user/.wine/drive_c/users/user"
 readonly ZWIFT_HOME="/home/user/.wine/drive_c/Program Files (x86)/Zwift"
-readonly ZWIFT_DOCS="${WINE_USER_HOME}/AppData/Local/Zwift"
+readonly ZWIFT_DOCS="${WINE_USER_HOME}/AppData/Local/ZwiftVolume" # WORKAROUND issue 366 (change ZwiftVolume to Zwift when fixed)
 
 if [[ -t 1 ]]; then
     readonly INTERACTIVE_TERMINAL="1"


### PR DESCRIPTION
## Summary

Workaround for https://github.com/netbrain/zwift/issues/366

## Implementation

1. Mount `zwift-$USER` volume to a `AppData/Local/ZwiftVolume`
2. Copy `AppData/Local/ZwiftVolume` to `AppData/Local/Zwift` using rsync
3. Launch Zwift
4. Wait for Zwift to exit
5. Copy `AppData/Local/Zwift` to `AppData/Local/ZwiftVolume` using rsync