### PR TITLE
Fix push github workflow

### DIFF
--- a/.github/workflows/zwift_push.yaml
+++ b/.github/workflows/zwift_push.yaml
@@ -56,4 +56,3 @@ jobs:
                 netbrain/zwift:latest
             docker push "netbrain/zwift:latest"
         fi
-        docker rm zwift


### PR DESCRIPTION
## Summary

The temporary docker container in the zwift push workflow was renamed to zwift-push in #376. But I forgot to update the container name in the docker rm command at the end of the workflow.

## Implementation

Instead of fixing the docker rm container name, remove it. There's no docker rm in the other workflows either.