### PR TITLE
Remove star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,6 @@ and tricks :smiley:
     cake, and have it too by creating `vgpus` for vms that leverage the host
     gpu, no dedicated gpu required
 
-## ⭐ Star History (for fun and giggles)
-
-<!-- markdownlint-disable line-length -->
-[![Star History Chart](https://api.star-history.com/chart?repos=netbrain/zwift&type=date&legend=top-left&sealed_token=P-GZDYcjNPXSdBBWv6fYd1q9l2QYn8RwOAazVYzhNjLm13SxhxXvWH23XUounM3eZAJJBr5inEk9A_US1aG03d8WpTJXkWZMl4s2nD8aVFNAqxc9p1YG9phmq_aCPO5FmQt7BOSE_8SvTJe7rKLd-9uaVV2NATlbf0_I9s5jVTorIS9JBoDqfSw99rm3)](https://www.star-history.com/?repos=netbrain%2Fzwift&type=date&legend=top-left)
-<!-- markdownlint-enable line-length -->
-
 [lint-everything-src]: https://github.com/netbrain/zwift/actions/workflows/lint_everything.yaml/badge.svg
 [lint-everything-href]: https://github.com/netbrain/zwift/actions/workflows/lint_everything.yaml
 [zwift-updater-src]: https://github.com/netbrain/zwift/actions/workflows/zwift_updater.yaml/badge.svg


### PR DESCRIPTION
Removes the star history chart section from the README.

- The official api.star-history.com embed is broken since GitHub restricted the Stargazers API to repo admins/collaborators (June 30, 2026). The sealed_token added in #368 now returns 401.
- Rather than pointing the README at a third-party mirror (#372), drop the chart until the official service works again without workarounds.

Closes #367