### PR TITLE
Enable dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly

--- a/.github/workflows/github_pages.yaml
+++ b/.github/workflows/github_pages.yaml
@@ -23,7 +23,7 @@ jobs:
         working-directory: docs
     steps:
     - name: Checkout repository code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/lint_everything.yaml
+++ b/.github/workflows/lint_everything.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Install bash language tools
       run: sudo apt-get install -y shellcheck
     - name: Check bash scripts for errors and warnings
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@v7
       with:
         go-version: '>=1.23'
         cache: false
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Install docker buildx
       uses: docker/setup-buildx-action@v4
     - name: Check Dockerfile for errors
@@ -49,9 +49,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Check Dockerfile for errors
-      uses: hadolint/hadolint-action@master
+      uses: hadolint/hadolint-action@v3.4.0
       with:
         config: .hadolint.yaml
         dockerfile: src/Dockerfile
@@ -60,17 +60,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Check github actions for errors
-      uses: devops-actions/actionlint@e7ee33fbf5aa8c9f9ee1145137f3e52e25d6a35b
+      uses: devops-actions/actionlint@9fb9c192862f19e684586ca84b500461bcd8a541
   markdown-lint:
     name: Markdown - Lint with markdownlint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Check markdown files for errors
-      uses: DavidAnson/markdownlint-cli2-action@v23
+      uses: DavidAnson/markdownlint-cli2-action@v24
       with:
         config: .markdownlint-cli2.yaml
         globs: ''
@@ -79,9 +79,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Spellcheck markdown files
-      uses: streetsidesoftware/cspell-action@v8
+      uses: streetsidesoftware/cspell-action@v9
       with:
         config: .cspell.yaml
         suggestions: true
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Install nix
       uses: cachix/install-nix-action@v31
     - name: Install nix language tools
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Install nix
       uses: cachix/install-nix-action@v31
     - name: Install nix language tools
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Install nix
       uses: cachix/install-nix-action@v31
     - name: Build nix flake
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Install yamllint
       run: sudo apt-get install -y yamllint
     - name: Check yaml files for errors

--- a/.github/workflows/sponsors.yaml
+++ b/.github/workflows/sponsors.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout 🛎️
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Generate Sponsors 💖
       uses: JamesIves/github-sponsors-readme-action@v1
       with:

--- a/.github/workflows/zwift_build_from_scratch.yaml
+++ b/.github/workflows/zwift_build_from_scratch.yaml
@@ -26,7 +26,7 @@ jobs:
       run: sudo apt-get install -y x11-xserver-utils x11-apps
     - uses: netbrain/free-disk-space-action@v0.0.1
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Build zwift
       run: |
         export DISPLAY=":99"

--- a/.github/workflows/zwift_push.yaml
+++ b/.github/workflows/zwift_push.yaml
@@ -19,7 +19,7 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Get latest zwift container and diff script files
       run: |
         docker pull netbrain/zwift:latest


### PR DESCRIPTION
## Summary

Enable automatic updates for github actions using dependabot.

- Add dependabot configuration file
- Update github actions

Dependabot will open a PR when an update for a github action is available.

## Implementation

- **Documentation**: [Keeping your actions up to date with Dependabot](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/auto-update-actions):

  ```yaml
  ---
  version: 2                             # must be set to 2
  updates:                               # which update check to run
  - package-ecosystem: github-actions    # enable updates for github actions
    directory: /                         # must be set to / for github actions
    schedule:                            # when to check for updates
      interval: weekly                   # check for updates once a week
  ```

- **TODO**: enable dependabot for netbrain/zwift:

  `settings > advanced security > dependabot > dependabot version updates > enable`

  <img width="916" height="86" alt="image" src="https://github.com/user-attachments/assets/823e63e3-a088-4833-aa8d-de196b16268b" />

## Discussion

Would it be useful (and possible) to enable dependabot updates for other dependencies?

- The devcontainer (`package-ecosystem: devcontainers`)
- The nix flake (`package-ecosystem: nix`)
- ...
